### PR TITLE
[Feat] 인증,인가, auth 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,14 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'at.favre.lib:bcrypt:0.10.2'
+
+    // jwt
+    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     //QueryDSL 추가

--- a/src/main/java/org/example/pdnight/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/example/pdnight/domain/auth/controller/AuthController.java
@@ -1,4 +1,54 @@
 package org.example.pdnight.domain.auth.controller;
 
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.auth.dto.request.LoginRequestDto;
+import org.example.pdnight.domain.auth.dto.request.SignInRequestDto;
+import org.example.pdnight.domain.auth.dto.request.WithdrawRequestDto;
+import org.example.pdnight.domain.auth.dto.response.LoginResponseDto;
+import org.example.pdnight.domain.auth.dto.response.SignInResponseDto;
+import org.example.pdnight.domain.auth.service.AuthService;
+import org.example.pdnight.domain.common.dto.ApiResponse;
+import org.example.pdnight.global.filter.CustomUserDetails;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Controller
+@RequiredArgsConstructor
 public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/api/auth/signup")
+    private ResponseEntity<ApiResponse<SignInResponseDto>> signIn(@Valid @RequestBody SignInRequestDto request) {
+        SignInResponseDto user = authService.signIn(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok("회원가입 되었습니다.", user));
+    }
+
+    @PostMapping("/api/auth/login")
+    private ResponseEntity<ApiResponse<LoginResponseDto>> login(@Valid @RequestBody LoginRequestDto request) {
+        LoginResponseDto token = authService.login(request);
+        return ResponseEntity.ok(ApiResponse.ok("로그인 되었습니다.", token));
+    }
+
+    @PostMapping("/api/auth/logout")
+    private ResponseEntity<ApiResponse<Void>> logout(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
+        authService.logout(userId);
+        return ResponseEntity.ok(ApiResponse.ok("로그아웃 되었습니다.", null));
+    }
+
+    @DeleteMapping("/api/auth/withdraw")
+    private ResponseEntity<ApiResponse<Void>> withdraw(@Valid @RequestBody WithdrawRequestDto request,
+                                                       @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
+        authService.withdraw(userId, request);
+        return ResponseEntity.ok(ApiResponse.ok("회원탈퇴 되었습니다.", null));
+    }
 }

--- a/src/main/java/org/example/pdnight/domain/auth/dto/request/LoginRequestDto.java
+++ b/src/main/java/org/example/pdnight/domain/auth/dto/request/LoginRequestDto.java
@@ -1,0 +1,16 @@
+package org.example.pdnight.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import org.example.pdnight.global.annotation.ValidEmailPattern;
+
+@Getter
+@Builder
+public class LoginRequestDto {
+    @NotBlank
+    @ValidEmailPattern
+    private String email;
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/org/example/pdnight/domain/auth/dto/request/LoginRequestDto.java
+++ b/src/main/java/org/example/pdnight/domain/auth/dto/request/LoginRequestDto.java
@@ -8,9 +8,9 @@ import org.example.pdnight.global.annotation.ValidEmailPattern;
 @Getter
 @Builder
 public class LoginRequestDto {
-    @NotBlank
+    @NotBlank(message = "이메일은 작성해야 합니다.")
     @ValidEmailPattern
     private String email;
-    @NotBlank
+    @NotBlank(message = "비밀번호를 작성해야 합니다.")
     private String password;
 }

--- a/src/main/java/org/example/pdnight/domain/auth/dto/request/SignInRequestDto.java
+++ b/src/main/java/org/example/pdnight/domain/auth/dto/request/SignInRequestDto.java
@@ -1,4 +1,50 @@
 package org.example.pdnight.domain.auth.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import org.example.pdnight.domain.common.enums.JobCategory;
+import org.example.pdnight.domain.post.enums.Gender;
+import org.example.pdnight.domain.user.enums.Region;
+import org.example.pdnight.global.annotation.ValidEmailPattern;
+
+@Getter
+@Builder
 public class SignInRequestDto {
+    @NotBlank(message = "이메일은 작성해야 합니다.")
+    @ValidEmailPattern
+    private String email;
+
+    @NotBlank(message = "비밀번호를 작성해야 합니다.")
+    private String password;
+
+    @NotBlank(message = "이름을 작성해야 합니다.")
+    private String name;
+
+    private String nickname;
+
+//    @NotBlank(message = "취미를 작성해야 합니다.")
+    private String hobby;
+
+//    @NotBlank(message = "기술 스택을 작성해야 합니다.")
+    private String techStack;
+
+    @NotNull(message = "성별을 작성해야 합니다.")
+    private Gender gender;
+
+    @NotNull(message = "나이를 작성해야 합니다.")
+    private Long age;
+
+    @NotNull(message = "직업을 작성해야 합니다.")
+    private JobCategory jobCategory;
+
+    @NotNull(message = "사는 지역을 작성해야 합니다.")
+    private Region region;
+
+    @NotNull(message = "근무 지역을 작성해야 합니다.")
+    private Region workLocation;
+
+    private String comment;
+
 }

--- a/src/main/java/org/example/pdnight/domain/auth/dto/request/WithdrawRequestDto.java
+++ b/src/main/java/org/example/pdnight/domain/auth/dto/request/WithdrawRequestDto.java
@@ -1,0 +1,10 @@
+package org.example.pdnight.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class WithdrawRequestDto {
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/org/example/pdnight/domain/auth/dto/request/WithdrawRequestDto.java
+++ b/src/main/java/org/example/pdnight/domain/auth/dto/request/WithdrawRequestDto.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 
 @Getter
 public class WithdrawRequestDto {
-    @NotBlank
+    @NotBlank(message = "비밀번호를 작성해야 합니다.")
     private String password;
 }

--- a/src/main/java/org/example/pdnight/domain/auth/dto/response/LoginResponseDto.java
+++ b/src/main/java/org/example/pdnight/domain/auth/dto/response/LoginResponseDto.java
@@ -1,0 +1,10 @@
+package org.example.pdnight.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponseDto {
+    private String token;
+}

--- a/src/main/java/org/example/pdnight/domain/auth/dto/response/SignInResponseDto.java
+++ b/src/main/java/org/example/pdnight/domain/auth/dto/response/SignInResponseDto.java
@@ -1,4 +1,60 @@
 package org.example.pdnight.domain.auth.dto.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.pdnight.domain.common.enums.JobCategory;
+import org.example.pdnight.domain.common.enums.UserRole;
+import org.example.pdnight.domain.post.enums.Gender;
+import org.example.pdnight.domain.user.entity.User;
+import org.example.pdnight.domain.user.enums.Region;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
 public class SignInResponseDto {
+    private String email;
+
+    private UserRole role;
+
+    private String name;
+
+    private String nickname;
+
+    private String hobby;
+
+    private String techStack;
+
+    private Gender gender;
+
+    private Long age;
+
+    private JobCategory jobCategory;
+
+    private Region region;
+
+    private Region workLocation;
+
+    private String comment;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updateAt;
+
+    public SignInResponseDto(User user, String hobby, String techStack) {
+        this.email = user.getEmail();
+        this.role = UserRole.USER;
+        this.name = user.getName();
+        this.nickname = user.getNickname();
+        this.hobby = hobby;
+        this.techStack = techStack;
+        this.gender = user.getGender();
+        this.age =  user.getAge();
+        this.jobCategory = user.getJobCategory();
+        this.region = user.getRegion();
+        this.workLocation = user.getWorkLocation();
+        this.comment = user.getComment();
+        this.createdAt = user.getCreatedAt();
+        this.updateAt = user.getUpdatedAt();
+    }
 }

--- a/src/main/java/org/example/pdnight/domain/auth/service/AuthService.java
+++ b/src/main/java/org/example/pdnight/domain/auth/service/AuthService.java
@@ -1,4 +1,100 @@
 package org.example.pdnight.domain.auth.service;
 
+import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.auth.dto.request.LoginRequestDto;
+import org.example.pdnight.domain.auth.dto.request.SignInRequestDto;
+import org.example.pdnight.domain.auth.dto.request.WithdrawRequestDto;
+import org.example.pdnight.domain.auth.dto.response.LoginResponseDto;
+import org.example.pdnight.domain.auth.dto.response.SignInResponseDto;
+import org.example.pdnight.domain.common.enums.ErrorCode;
+import org.example.pdnight.domain.common.exception.BaseException;
+import org.example.pdnight.domain.hobby.entity.Hobby;
+import org.example.pdnight.domain.hobby.repository.HobbyRepository;
+import org.example.pdnight.domain.techStack.entity.TechStack;
+import org.example.pdnight.domain.techStack.repository.TechStackRepository;
+import org.example.pdnight.domain.user.entity.User;
+import org.example.pdnight.domain.user.repository.UserRepository;
+import org.example.pdnight.global.config.PasswordEncoder;
+import org.example.pdnight.global.utils.JwtUtil;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
 public class AuthService {
+
+    private final UserRepository userRepository;
+    private final HobbyRepository hobbyRepository;
+    private final TechStackRepository techStackRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    @Transactional
+    public SignInResponseDto signIn(SignInRequestDto request) {
+
+        if (userRepository.findByEmail(request.getEmail()).isPresent()) {
+            throw new BaseException(ErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+
+        // 취미, 기술 스택 입력은 db에 존재하는 값만 입력받는 조건
+        Hobby hobby = null;
+        String hobbyStr = null;
+        if (request.getHobby() != null) {
+            hobby = hobbyRepository.findByhobby(request.getHobby());
+            hobbyStr = hobby.getHobby();
+        }
+
+        TechStack techStack = null;
+        String techStackStr = null;
+        if (request.getTechStack() != null) {
+            techStack = techStackRepository.findByTechStack(request.getTechStack());
+            techStackStr = techStack.getTechStack();
+        }
+
+        String encodePassword = passwordEncoder.encode(request.getPassword());
+        User user = new User(request, encodePassword, hobby, techStack);
+
+        User saveUser = userRepository.save(user);
+
+        return new SignInResponseDto(saveUser, hobbyStr, techStackStr);
+
+    }
+
+    @Transactional
+    public LoginResponseDto login(LoginRequestDto request) {
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
+
+        if(user.getIsDeleted()) {
+            throw new BaseException(ErrorCode.USER_DEACTIVATED);
+        }
+
+        if(!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new BaseException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        String token = jwtUtil.createToken(user.getId(), user.getRole());
+        return new LoginResponseDto(token);
+    }
+
+    public void logout(Long userId) {
+
+    }
+
+    @Transactional
+    public void withdraw(Long userId, WithdrawRequestDto request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
+
+        if(user.getIsDeleted()) {
+            throw new BaseException(ErrorCode.USER_DEACTIVATED);
+        }
+
+        if(!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new BaseException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        user.softDelete();
+    }
+
 }

--- a/src/main/java/org/example/pdnight/domain/hobby/repository/HobbyRepository.java
+++ b/src/main/java/org/example/pdnight/domain/hobby/repository/HobbyRepository.java
@@ -3,5 +3,6 @@ package org.example.pdnight.domain.hobby.repository;
 import org.example.pdnight.domain.hobby.entity.Hobby;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface HobbyRepository extends JpaRepository<Hobby,Long> {
+public interface HobbyRepository extends JpaRepository<Hobby, Long> {
+    Hobby findByhobby(String hobby);
 }

--- a/src/main/java/org/example/pdnight/domain/techStack/repository/TechStackRepository.java
+++ b/src/main/java/org/example/pdnight/domain/techStack/repository/TechStackRepository.java
@@ -4,4 +4,5 @@ import org.example.pdnight.domain.techStack.entity.TechStack;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TechStackRepository extends JpaRepository<TechStack, Long> {
+    TechStack findByTechStack(String techStack);
 }

--- a/src/main/java/org/example/pdnight/domain/user/entity/User.java
+++ b/src/main/java/org/example/pdnight/domain/user/entity/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.pdnight.domain.auth.dto.request.SignInRequestDto;
 import org.example.pdnight.domain.common.entity.Timestamped;
 import org.example.pdnight.domain.common.enums.UserRole;
 import org.example.pdnight.domain.hobby.entity.Hobby;
@@ -12,6 +13,8 @@ import org.example.pdnight.domain.common.enums.JobCategory;
 import org.example.pdnight.domain.techStack.entity.TechStack;
 import org.example.pdnight.domain.user.enums.Region;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "users")
 @Getter
@@ -19,6 +22,7 @@ import org.example.pdnight.domain.user.enums.Region;
 @AllArgsConstructor
 public class User extends Timestamped {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false, length = 255)
@@ -35,11 +39,11 @@ public class User extends Timestamped {
 
     private String nickname;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "hobby_id")
     private Hobby hobby;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "teck_stack_id")
     private TechStack techStack;
 
@@ -62,4 +66,30 @@ public class User extends Timestamped {
 
     private Long totalRate;
     private Long totalReviewer;
+
+    private Boolean isDeleted = false;
+    private LocalDateTime deletedAt;
+
+    public User(SignInRequestDto request, String encodePassword, Hobby hobby, TechStack techStack) {
+        this.email = request.getEmail();
+        this.password = encodePassword;
+        this.role = UserRole.USER;
+        this.name = request.getName();
+        this.nickname = request.getNickname();
+        this.hobby = hobby;
+        this.techStack = techStack;
+        this.gender = request.getGender();
+        this.age =  request.getAge();
+        this.jobCategory = request.getJobCategory();
+        this.region = request.getRegion();
+        this.workLocation = request.getWorkLocation();
+        this.comment = request.getComment();
+        this.totalRate = 0L;
+        this.totalReviewer = 0L;
+    }
+
+    public void softDelete() {
+        isDeleted = true;
+        deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/org/example/pdnight/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/pdnight/domain/user/repository/UserRepository.java
@@ -3,5 +3,8 @@ package org.example.pdnight.domain.user.repository;
 import org.example.pdnight.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/org/example/pdnight/global/annotation/ValidEmailPattern.java
+++ b/src/main/java/org/example/pdnight/global/annotation/ValidEmailPattern.java
@@ -1,0 +1,23 @@
+package org.example.pdnight.global.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.constraints.Pattern;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {})
+@Pattern(regexp = "^[\\w!#$%&'*+/=?`{|}~^.-]+@[\\w.-]+\\.[a-zA-Z]{2,6}$", message = "이메일 형식이 올바르지 않습니다.")
+public @interface ValidEmailPattern {
+    String message()
+            default "이메일 형식이 올바르지 않습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/example/pdnight/global/config/SecurityConfig.java
+++ b/src/main/java/org/example/pdnight/global/config/SecurityConfig.java
@@ -22,8 +22,6 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
-                //CORS 설정 추가
-                .cors(cors -> {})
                 .csrf(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)

--- a/src/main/java/org/example/pdnight/global/config/SecurityConfig.java
+++ b/src/main/java/org/example/pdnight/global/config/SecurityConfig.java
@@ -1,0 +1,38 @@
+package org.example.pdnight.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.example.pdnight.global.filter.JwtFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
+public class SecurityConfig {
+
+    private final JwtFilter jwtFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                //CORS 설정 추가
+                .cors(cors -> {})
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .addFilterBefore(jwtFilter, SecurityContextHolderAwareRequestFilter.class)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/signup").permitAll()
+                        .requestMatchers("/api/auth/login").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .build();
+    }
+}

--- a/src/main/java/org/example/pdnight/global/filter/CustomUserDetails.java
+++ b/src/main/java/org/example/pdnight/global/filter/CustomUserDetails.java
@@ -1,0 +1,25 @@
+package org.example.pdnight.global.filter;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.common.enums.UserRole;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+    private final Long userId;
+    private final String username;
+    private final String password;
+    private final UserRole userRole;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + userRole));
+    }
+}

--- a/src/main/java/org/example/pdnight/global/filter/JwtFilter.java
+++ b/src/main/java/org/example/pdnight/global/filter/JwtFilter.java
@@ -1,0 +1,98 @@
+package org.example.pdnight.global.filter;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.pdnight.domain.common.enums.UserRole;
+import org.example.pdnight.global.utils.JwtUtil;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtFilter implements Filter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        Filter.super.init(filterConfig);
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        String url = httpRequest.getRequestURI();
+
+        if (url.startsWith("/api/auth/signup") || url.startsWith("/api/auth/login")) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String bearerJwt = httpRequest.getHeader("Authorization");
+
+        if (bearerJwt == null || !bearerJwt.startsWith("Bearer ")) {
+            log.error("JWT 토큰이 필요합니다.");
+            sendError(httpResponse, 400,"JWT 토큰이 필요합니다.");
+            return;
+        }
+
+        String jwt = jwtUtil.substringToken(bearerJwt);
+
+        try {
+            Claims claims = jwtUtil.extractClaims(jwt);
+            if (claims == null) {
+                log.error("잘못된 JWT 토큰입니다.");
+                sendError(httpResponse, 400,"잘못된 JWT 토큰입니다.");
+                return;
+            }
+
+            UserRole userRole = claims.get("Role", UserRole.class);
+
+            Long userId = Long.parseLong(claims.getSubject());
+
+            CustomUserDetails userDetails = new CustomUserDetails(
+                    userId,
+                    "",
+                    "",
+                    userRole);
+
+            SecurityContextHolder.getContext().setAuthentication(
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+            );
+
+            chain.doFilter(request, response);
+        } catch (SecurityException | MalformedJwtException e) {
+            log.error("유효하지 않는 JWT 서명 입니다.", e);
+            sendError(httpResponse, 401,"유효하지 않는 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            log.error("만료된 JWT token 입니다.", e);
+            sendError(httpResponse, 401,"만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.error("지원되지 않는 JWT 토큰 입니다.", e);
+            sendError(httpResponse, 400,"지원되지 않는 JWT 토큰입니다.");
+        } catch (Exception e) {
+            log.error("Internal server error", e);
+            sendError(httpResponse, 500,"Internal server error.");
+        }
+    }
+
+    private void sendError(HttpServletResponse response, int status, String message) throws IOException {
+        response.setStatus(status);
+        response.setContentType("application/json; charset=UTF-8"); // 한 번만 설정
+        response.setCharacterEncoding("UTF-8"); // 명시적 인코딩
+        response.getWriter().write("{\"error\": \"" + message + "\"}");
+    }
+}

--- a/src/main/java/org/example/pdnight/global/utils/JwtUtil.java
+++ b/src/main/java/org/example/pdnight/global/utils/JwtUtil.java
@@ -1,0 +1,59 @@
+package org.example.pdnight.global.utils;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.example.pdnight.domain.common.enums.UserRole;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j(topic = "JwtUtil")
+@Component
+public class JwtUtil {
+    public static final String BEARER_PREFIX = "Bearer ";
+    private final long TOKEN_TIME = 30 * 60 * 1000L; // 30분
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public String createToken(Long userId, UserRole userRole) {
+        Date date = new Date();
+
+        return Jwts.builder()
+                        .setSubject(String.valueOf(userId))
+                        .claim("userRole", userRole)
+                        .setExpiration(new Date(date.getTime() + TOKEN_TIME))
+                        .setIssuedAt(date)
+                        .signWith(key, signatureAlgorithm)
+                        .compact();
+    }
+
+    public String substringToken(String tokenValue){
+        if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
+            return tokenValue.substring(7);
+        }
+        return null;
+    }
+
+    public Claims extractClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,5 @@ spring.jpa.properties.hibernate.use_sql_comments=true
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+
+jwt.secret.key=${JWT_SECRET_KEY}

--- a/src/test/java/org/example/pdnight/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/org/example/pdnight/domain/auth/controller/AuthControllerTest.java
@@ -1,0 +1,90 @@
+package org.example.pdnight.domain.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.pdnight.domain.auth.dto.request.LoginRequestDto;
+import org.example.pdnight.domain.auth.dto.request.SignInRequestDto;
+import org.example.pdnight.domain.common.enums.JobCategory;
+import org.example.pdnight.domain.post.enums.Gender;
+import org.example.pdnight.domain.user.enums.Region;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @Rollback
+    @DisplayName("회원 가입 성공 테스트")
+    void signInSuccess() throws Exception {
+        //given
+        SignInRequestDto request = signInRequest("SignIn");
+
+        //when
+        ResultActions perform = mockMvc.perform(post("/api/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        //then
+        perform.andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.email").value("SignInTest@example.com"));
+    }
+
+    @Test
+    @Rollback
+    @DisplayName("로그인 성공 테스트")
+    void loginSuccess() throws Exception {
+        //given
+        SignInRequestDto request = signInRequest("login");
+
+        mockMvc.perform(post("/api/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        LoginRequestDto loginRequest = LoginRequestDto.builder()
+                .email("loginTest@example.com")
+                .password("testPassword").build();
+
+        //when
+        ResultActions perform = mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)));
+
+        //then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.token").isNotEmpty());
+    }
+
+    private SignInRequestDto signInRequest(String name) {
+        return SignInRequestDto.builder()
+                .email(name + "Test@example.com")
+                .password("testPassword")
+                .name("test")
+                .gender(Gender.MALE)
+                .age(20L)
+                .jobCategory(JobCategory.BACK_END_DEVELOPER)
+                .region(Region.PANGYO_DONG)
+                .workLocation(Region.BAEKHYEON_DONG).build();
+    }
+}


### PR DESCRIPTION
### 인증, 인가, auth 기능 구현 내용

JWT 필터 적용, 토큰 생성
 - global/ filter, utils 파일에 구현

spring Security 적용
 - global/config/SecurityConfig 적용

auth 회원가입, 로그인, 회원탈퇴(soft delete) 구현
 - domain/auth 구현

User Entity
- hobby, techStack  : OneToOne 연관 관계에서 ManyToOne으로 수정

취미, 기술 스택 db에 추가하려면 인증, 인가 작업을 거쳐야 해서 일단 null 가능으로 설정
로그아웃은 추후 Cache 적용 시 추가 예정