### PR TITLE
Feat/user kmg

### DIFF
--- a/src/main/java/org/example/pdnight/domain/common/enums/ErrorCode.java
+++ b/src/main/java/org/example/pdnight/domain/common/enums/ErrorCode.java
@@ -35,7 +35,14 @@ public enum ErrorCode {
     MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, "필수 입력값이 누락되었습니다"),
 
     // 서버 오류 (500 Internal Server Error)
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "처리 중 오류가 발생했습니다")
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "처리 중 오류가 발생했습니다"),
+
+    //취미 관련 오류
+    HOBBY_ALREADY_EXISTS(HttpStatus.CONFLICT,"이미 존재하는 취미 입니다"),
+
+    //기술 스택 관련 오류
+    TECH_STACK_ALREADY_EXISTS(HttpStatus.CONFLICT,"이미 존재하는 기술 스택입니다")
+
 
     ;
 

--- a/src/main/java/org/example/pdnight/domain/common/exception/BaseException.java
+++ b/src/main/java/org/example/pdnight/domain/common/exception/BaseException.java
@@ -1,6 +1,7 @@
 package org.example.pdnight.domain.common.exception;
 
 import lombok.Getter;
+import org.example.pdnight.domain.common.enums.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 @Getter
@@ -14,5 +15,11 @@ public class BaseException extends RuntimeException {
         super(message);
         this.status = status;
         this.message = message;
+    }
+
+    public BaseException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.status = errorCode.getStatus();
+        this.message = errorCode.getMessage();
     }
 }

--- a/src/main/java/org/example/pdnight/domain/hobby/entity/Hobby.java
+++ b/src/main/java/org/example/pdnight/domain/hobby/entity/Hobby.java
@@ -16,6 +16,7 @@ public class Hobby extends Timestamped{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "hobby", unique = true)
     private String hobby;
 
     public Hobby(String hobby){

--- a/src/main/java/org/example/pdnight/domain/hobby/repository/HobbyRepository.java
+++ b/src/main/java/org/example/pdnight/domain/hobby/repository/HobbyRepository.java
@@ -1,7 +1,9 @@
 package org.example.pdnight.domain.hobby.repository;
 
+import jakarta.validation.constraints.NotNull;
 import org.example.pdnight.domain.hobby.entity.Hobby;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HobbyRepository extends JpaRepository<Hobby,Long> {
+    Boolean existsHobbiesByHobby(@NotNull String hobby);
 }

--- a/src/main/java/org/example/pdnight/domain/hobby/service/HobbyService.java
+++ b/src/main/java/org/example/pdnight/domain/hobby/service/HobbyService.java
@@ -2,6 +2,8 @@ package org.example.pdnight.domain.hobby.service;
 
 
 import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.common.enums.ErrorCode;
+import org.example.pdnight.domain.common.exception.BaseException;
 import org.example.pdnight.domain.hobby.dto.request.HobbyRequest;
 import org.example.pdnight.domain.hobby.dto.response.HobbyResponse;
 import org.example.pdnight.domain.hobby.entity.Hobby;
@@ -19,6 +21,12 @@ public class HobbyService {
     private final HobbyRepositoryQuery hobbyRepositoryQuery;
 
     public HobbyResponse createHobby(HobbyRequest dto){
+        Boolean exists = hobbyRepository.existsHobbiesByHobby(dto.getHobby());
+
+        if (exists){
+            throw new BaseException(ErrorCode.HOBBY_ALREADY_EXISTS);
+        }
+
         Hobby hobby = new Hobby(dto.getHobby());
 
         Hobby save = hobbyRepository.save(hobby);

--- a/src/main/java/org/example/pdnight/domain/post/dto/response/PostResponseDto.java
+++ b/src/main/java/org/example/pdnight/domain/post/dto/response/PostResponseDto.java
@@ -3,6 +3,7 @@ package org.example.pdnight.domain.post.dto.response;
 import java.time.LocalDateTime;
 
 import org.example.pdnight.domain.common.enums.JobCategory;
+import org.example.pdnight.domain.post.entity.Post;
 import org.example.pdnight.domain.post.enums.AgeLimit;
 import org.example.pdnight.domain.post.enums.Gender;
 import org.example.pdnight.domain.post.enums.PostStatus;
@@ -28,5 +29,20 @@ public class PostResponseDto {
 	private final Gender genderLimit;
 	private final JobCategory jobCategoryLimit;
 	private final AgeLimit ageLimit;
+
+	public static PostResponseDto toDto(Post post){
+		return new PostResponseDto(
+				post.getId(),
+				post.getAuthor().getId(),
+				post.getTitle(),
+				post.getTimeSlot(),
+				post.getPublicContent(),
+				post.getPrivateContent(),
+				post.getStatus(),
+				post.getMaxParticipants(),
+				post.getGenderLimit(),
+				post.getJobCategoryLimit(),
+				post.getAgeLimit());
+	}
 
 }

--- a/src/main/java/org/example/pdnight/domain/post/repository/PostRepositoryQuery.java
+++ b/src/main/java/org/example/pdnight/domain/post/repository/PostRepositoryQuery.java
@@ -1,0 +1,16 @@
+package org.example.pdnight.domain.post.repository;
+
+import org.example.pdnight.domain.participant.enums.JoinStatus;
+import org.example.pdnight.domain.post.dto.response.PostResponseDto;
+import org.example.pdnight.domain.post.entity.Post;
+import org.example.pdnight.domain.user.dto.response.PostWithJoinStatusAndAppliedAtResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostRepositoryQuery {
+    Page<Post> getMyLikePost(Long userId, Pageable pageable);
+
+    Page<PostWithJoinStatusAndAppliedAtResponseDto> getConfirmedPost(Long userId, JoinStatus joinStatus, Pageable pageable);
+}

--- a/src/main/java/org/example/pdnight/domain/post/repository/PostRepositoryQueryImpl.java
+++ b/src/main/java/org/example/pdnight/domain/post/repository/PostRepositoryQueryImpl.java
@@ -1,0 +1,103 @@
+package org.example.pdnight.domain.post.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.participant.entity.QPostParticipant;
+import org.example.pdnight.domain.participant.enums.JoinStatus;
+import org.example.pdnight.domain.post.entity.Post;
+import org.example.pdnight.domain.post.entity.QPost;
+import org.example.pdnight.domain.post.enums.PostStatus;
+import org.example.pdnight.domain.post.service.PostService;
+import org.example.pdnight.domain.postLike.entity.QPostLike;
+import org.example.pdnight.domain.user.dto.response.PostWithJoinStatusAndAppliedAtResponseDto;
+import org.example.pdnight.domain.user.dto.response.QPostWithJoinStatusAndAppliedAtResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class PostRepositoryQueryImpl implements PostRepositoryQuery{
+    private final JPAQueryFactory queryFactory;
+
+    public Page<Post> getMyLikePost(Long userId, Pageable pageable){
+        QPost post = QPost.post;
+        QPostLike postLike = QPostLike.postLike;
+
+        List<Post> content = queryFactory
+                .select(post)
+                .from(post)
+                .join(postLike).on(postLike.post.eq(post))
+                .where(postLike.user.id.eq(userId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long count = queryFactory
+                .select(post.count())
+                .from(post)
+                .join(postLike).on(postLike.post.eq(post))
+                .where(postLike.user.id.eq(userId))
+                .fetchOne();
+
+        return PageableExecutionUtils.getPage(content, pageable, () -> Optional.ofNullable(count).orElse(0L));
+    }
+
+    @Override
+    public Page<PostWithJoinStatusAndAppliedAtResponseDto> getConfirmedPost(Long userId,JoinStatus joinStatus,Pageable pageable) {
+        QPost post = QPost.post;
+        QPostParticipant postParticipant = QPostParticipant.postParticipant;
+
+        QPostWithJoinStatusAndAppliedAtResponseDto qPostWithStatusResponseDto = new QPostWithJoinStatusAndAppliedAtResponseDto(
+                post.id,
+                post.author.id,
+                post.title,
+                post.timeSlot,
+                post.publicContent,
+                post.privateContent,
+                post.status,
+                post.maxParticipants,
+                post.genderLimit,
+                post.jobCategoryLimit,
+                post.ageLimit,
+                postParticipant.status,
+                postParticipant.createdAt);
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(postParticipant.user.id.eq(userId));
+        builder.and(post.status.ne(PostStatus.CLOSED));
+
+        if (joinStatus!=null){
+            builder.and(postParticipant.status.eq(joinStatus));
+        }
+
+
+        List<PostWithJoinStatusAndAppliedAtResponseDto> content = queryFactory
+                .select(qPostWithStatusResponseDto)
+                .from(post)
+                .join(postParticipant).on(postParticipant.post.eq(post))
+                .where(
+                        builder
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long count = queryFactory
+                .select(post.count())
+                .from(post)
+                .join(postParticipant).on(postParticipant.post.eq(post))
+                .where(
+                        builder
+                )
+                .fetchOne();
+
+        return PageableExecutionUtils.getPage(content, pageable, () -> Optional.ofNullable(count).orElse(0L));
+    }
+}

--- a/src/main/java/org/example/pdnight/domain/techStack/entity/TechStack.java
+++ b/src/main/java/org/example/pdnight/domain/techStack/entity/TechStack.java
@@ -16,7 +16,8 @@ public class TechStack extends Timestamped {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "tech_stack")
+
+    @Column(name = "tech_stack", unique = true)
     private String techStack;
 
     public TechStack(String techStack){

--- a/src/main/java/org/example/pdnight/domain/techStack/repository/TechStackRepository.java
+++ b/src/main/java/org/example/pdnight/domain/techStack/repository/TechStackRepository.java
@@ -1,7 +1,9 @@
 package org.example.pdnight.domain.techStack.repository;
 
+import jakarta.validation.constraints.NotNull;
 import org.example.pdnight.domain.techStack.entity.TechStack;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TechStackRepository extends JpaRepository<TechStack, Long> {
+    boolean existsTechStackByTechStack(@NotNull String techStack);
 }

--- a/src/main/java/org/example/pdnight/domain/techStack/service/TechStackService.java
+++ b/src/main/java/org/example/pdnight/domain/techStack/service/TechStackService.java
@@ -21,7 +21,7 @@ public class TechStackService {
     public TechStackResponseDto createTechStack(TechStackRequestDto dto) {
         boolean exists = techStackRepository.existsTechStackByTechStack(dto.getTechStack());
         if (exists) {
-            throw new BaseException(ErrorCode.INVALID_INPUT);
+            throw new BaseException(ErrorCode.TECH_STACK_ALREADY_EXISTS);
         }
         TechStack techStack = new TechStack(dto.getTechStack());
         TechStack save = techStackRepository.save(techStack);

--- a/src/main/java/org/example/pdnight/domain/techStack/service/TechStackService.java
+++ b/src/main/java/org/example/pdnight/domain/techStack/service/TechStackService.java
@@ -1,6 +1,8 @@
 package org.example.pdnight.domain.techStack.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.common.enums.ErrorCode;
+import org.example.pdnight.domain.common.exception.BaseException;
 import org.example.pdnight.domain.techStack.dto.request.TechStackRequestDto;
 import org.example.pdnight.domain.techStack.dto.response.TechStackResponseDto;
 import org.example.pdnight.domain.techStack.entity.TechStack;
@@ -17,6 +19,10 @@ public class TechStackService {
     private final TechStackRepositoryQuery techStackRepositoryQuery;
 
     public TechStackResponseDto createTechStack(TechStackRequestDto dto) {
+        boolean exists = techStackRepository.existsTechStackByTechStack(dto.getTechStack());
+        if (exists) {
+            throw new BaseException(ErrorCode.INVALID_INPUT);
+        }
         TechStack techStack = new TechStack(dto.getTechStack());
         TechStack save = techStackRepository.save(techStack);
         return TechStackResponseDto.of(save);

--- a/src/main/java/org/example/pdnight/domain/user/controller/UserController.java
+++ b/src/main/java/org/example/pdnight/domain/user/controller/UserController.java
@@ -1,13 +1,40 @@
 package org.example.pdnight.domain.user.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.common.dto.ApiResponse;
+import org.example.pdnight.domain.common.dto.PagedResponse;
+import org.example.pdnight.domain.participant.enums.JoinStatus;
+import org.example.pdnight.domain.post.dto.response.PostResponseDto;
+import org.example.pdnight.domain.user.dto.request.ConfirmedPostRequestDto;
+import org.example.pdnight.domain.user.dto.response.PostWithJoinStatusAndAppliedAtResponseDto;
 import org.example.pdnight.domain.user.service.UserService;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
+
+    @GetMapping("/my/likedPosts")
+    public ResponseEntity<ApiResponse<PagedResponse<PostResponseDto>>> getMyLikedPosts(
+            @RequestParam Long id,
+            @PageableDefault(size = 10,page = 0) Pageable pageable
+    ){
+        PagedResponse<PostResponseDto> myLikedPost = userService.findMyLikedPosts(id, pageable);
+        return ResponseEntity.ok(ApiResponse.ok("내 좋아요 게시글 목록이 조회되었습니다.",myLikedPost));
+    }
+
+    @GetMapping("/my/confirmedPosts")
+    public ResponseEntity<ApiResponse<PagedResponse<PostWithJoinStatusAndAppliedAtResponseDto>>> getMyConfirmedPosts(
+            @RequestParam Long id,
+            @RequestParam JoinStatus joinStatus,
+            @PageableDefault(size = 10,page = 0) Pageable pageable
+    ){
+        PagedResponse<PostWithJoinStatusAndAppliedAtResponseDto> myLikedPost = userService.findMyConfirmedPosts(id,joinStatus, pageable);
+        return ResponseEntity.ok(ApiResponse.ok("참여 신청한 게시글 목록이 조회되었습니다.",myLikedPost));
+    }
 }

--- a/src/main/java/org/example/pdnight/domain/user/controller/UserController.java
+++ b/src/main/java/org/example/pdnight/domain/user/controller/UserController.java
@@ -31,7 +31,7 @@ public class UserController {
     @GetMapping("/my/confirmedPosts")
     public ResponseEntity<ApiResponse<PagedResponse<PostWithJoinStatusAndAppliedAtResponseDto>>> getMyConfirmedPosts(
             @RequestParam Long id,
-            @RequestParam JoinStatus joinStatus,
+            @RequestParam (required = false) JoinStatus joinStatus,
             @PageableDefault(size = 10,page = 0) Pageable pageable
     ){
         PagedResponse<PostWithJoinStatusAndAppliedAtResponseDto> myLikedPost = userService.findMyConfirmedPosts(id,joinStatus, pageable);

--- a/src/main/java/org/example/pdnight/domain/user/dto/request/ConfirmedPostRequestDto.java
+++ b/src/main/java/org/example/pdnight/domain/user/dto/request/ConfirmedPostRequestDto.java
@@ -1,0 +1,11 @@
+package org.example.pdnight.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import org.example.pdnight.domain.participant.enums.JoinStatus;
+
+@Getter
+public class ConfirmedPostRequestDto {
+    @NotNull
+    private JoinStatus joinStatus;
+}

--- a/src/main/java/org/example/pdnight/domain/user/dto/response/PostWithJoinStatusAndAppliedAtResponseDto.java
+++ b/src/main/java/org/example/pdnight/domain/user/dto/response/PostWithJoinStatusAndAppliedAtResponseDto.java
@@ -1,0 +1,59 @@
+package org.example.pdnight.domain.user.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import org.example.pdnight.domain.common.enums.JobCategory;
+import org.example.pdnight.domain.participant.enums.JoinStatus;
+import org.example.pdnight.domain.post.enums.AgeLimit;
+import org.example.pdnight.domain.post.enums.Gender;
+import org.example.pdnight.domain.post.enums.PostStatus;
+
+@Getter
+public class PostWithJoinStatusAndAppliedAtResponseDto {
+
+    private final Long postId;
+    private final Long userId;
+    private final String title;
+    private final LocalDateTime timeslot;
+    private final String publicContent;
+    private final String privateContent;
+    private final PostStatus status;
+    private final Integer maxParticipants;
+    private final Gender genderLimit;
+    private final JobCategory jobCategoryLimit;
+    private final AgeLimit ageLimit;
+    private final JoinStatus joinStatus;
+    private final LocalDateTime appliedAt;
+
+    @QueryProjection
+    public PostWithJoinStatusAndAppliedAtResponseDto(Long postId,
+                                     Long userId,
+                                     String title,
+                                     LocalDateTime timeslot,
+                                     String publicContent,
+                                     String privateContent,
+                                     PostStatus status,
+                                     Integer maxParticipants,
+                                     Gender genderLimit,
+                                     JobCategory jobCategoryLimit,
+                                     AgeLimit ageLimit,
+                                     JoinStatus joinStatus,
+                                     LocalDateTime appliedAt) {
+        this.postId = postId;
+        this.userId = userId;
+        this.title = title;
+        this.timeslot = timeslot;
+        this.publicContent = publicContent;
+        this.privateContent = privateContent;
+        this.status = status;
+        this.maxParticipants = maxParticipants;
+        this.genderLimit = genderLimit;
+        this.jobCategoryLimit = jobCategoryLimit;
+        this.ageLimit = ageLimit;
+        this.joinStatus = joinStatus;
+        this.appliedAt =  appliedAt;
+    }
+}
+

--- a/src/main/java/org/example/pdnight/domain/user/service/UserService.java
+++ b/src/main/java/org/example/pdnight/domain/user/service/UserService.java
@@ -1,7 +1,29 @@
 package org.example.pdnight.domain.user.service;
 
+import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.common.dto.PagedResponse;
+import org.example.pdnight.domain.participant.enums.JoinStatus;
+import org.example.pdnight.domain.post.dto.response.PostResponseDto;
+import org.example.pdnight.domain.post.entity.Post;
+import org.example.pdnight.domain.post.repository.PostRepositoryQuery;
+import org.example.pdnight.domain.user.dto.response.PostWithJoinStatusAndAppliedAtResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class UserService {
+    private final PostRepositoryQuery postRepositoryQuery;
+
+    public PagedResponse<PostResponseDto> findMyLikedPosts(Long userId, Pageable pageable){
+        Page<Post> myLikePost = postRepositoryQuery.getMyLikePost(userId, pageable);
+        Page<PostResponseDto> postResponseDtos = myLikePost.map(PostResponseDto::toDto);
+        return PagedResponse.from(postResponseDtos);
+    }
+
+    public PagedResponse<PostWithJoinStatusAndAppliedAtResponseDto> findMyConfirmedPosts(Long userId, JoinStatus joinStatus, Pageable pageable){
+        Page<PostWithJoinStatusAndAppliedAtResponseDto> myLikePost = postRepositoryQuery.getConfirmedPost(userId,joinStatus, pageable);
+        return PagedResponse.from(myLikePost);
+    }
 }


### PR DESCRIPTION
## PR 요약: 게시글 좋아요/신청 목록 조회 기능 추가

### 주요 변경 사항

- `내가 좋아요 누른 게시글 목록` 조회 API 추가
    - `GET /api/users/my/likedPosts?id={userId}`
- `내가 신청한 게시글 목록` 조회 API 추가 (선택적 상태 필터링 지원)
    - `GET /api/users/my/confirmedPosts?id={userId}&joinStatus={status}`
- 게시글 참여 상태 및 신청 일시 포함 DTO(`PostWithJoinStatusAndAppliedAtResponseDto`) 추가
    - `@QueryProjection` 기반으로 QueryDSL 매핑
- `PostRepositoryQuery`, `PostRepositoryQueryImpl` 클래스 추가 및 QueryDSL 기반 로직 구현
- `Hobby`, `TechStack` 중복 생성 방지 로직 추가
    - `existsByHobby`, `existsByTechStack` 메서드 추가
    - 중복 시 `BaseException` 발생 (`ErrorCode` 확장)