### PR TITLE
Feat/user v2 kmg

### DIFF
--- a/src/main/java/org/example/pdnight/domain/common/enums/ErrorCode.java
+++ b/src/main/java/org/example/pdnight/domain/common/enums/ErrorCode.java
@@ -29,14 +29,15 @@ public enum ErrorCode {
     POST_FORBIDDEN(HttpStatus.FORBIDDEN, "작성자만 접근할 수 있습니다."),
 
     // 게시물 신청 관련 에러
-    CANNOT_PARTICIPANT_SELF(HttpStatus.BAD_REQUEST, "본인 게시글엔 신청할 수 없습니다."),
+    CANNOT_PARTICIPATE_SELF(HttpStatus.BAD_REQUEST, "본인 게시글엔 신청할 수 없습니다."),
     POST_ALREADY_PENDING(HttpStatus.CONFLICT, "이미 신청했습니다."),
     POST_ALREADY_ACCEPTED(HttpStatus.CONFLICT, "이미 가입되어있습니다."),
     CANNOT_CANCEL(HttpStatus.BAD_REQUEST, "취소할 수 없습니다."),
-    NOT_PARTICIPANT(HttpStatus.BAD_REQUEST, "신청되어있지 않습니다."),
+    NOT_PARTICIPATED(HttpStatus.BAD_REQUEST, "신청되어있지 않습니다."),
     NOT_CHANGE_PENDING(HttpStatus.BAD_REQUEST, "대기 상태로 만들 수 없습니다."),
     NO_VIEWING_PERMISSION(HttpStatus.FORBIDDEN, "조회 권한이 없습니다."),
     NO_UPDATE_PERMISSION(HttpStatus.FORBIDDEN, "수정 권한이 없습니다."),
+    CANNOT_PARTICIPATE_POST(HttpStatus.FORBIDDEN,"참가 인원이 모두 찼습니다."),
 
     // 게시물 좋아요 관련 에러
     POSTLIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "게시물 좋아요를 찾을 수 없습니다"),

--- a/src/main/java/org/example/pdnight/domain/common/enums/ErrorCode.java
+++ b/src/main/java/org/example/pdnight/domain/common/enums/ErrorCode.java
@@ -28,6 +28,10 @@ public enum ErrorCode {
     TASK_STATE_FLOW_ERROR(HttpStatus.BAD_REQUEST, "Task 상태 변경 흐름이 올바르지 않습니다."),
     POST_FORBIDDEN(HttpStatus.FORBIDDEN, "작성자만 접근할 수 있습니다."),
 
+    // 게시물 좋아요 관련 에러
+    POSTLIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "게시물 좋아요를 찾을 수 없습니다"),
+    ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 누른 게시글입니다."),
+
     // 게시물 신청 관련 에러
     CANNOT_PARTICIPATE_SELF(HttpStatus.BAD_REQUEST, "본인 게시글엔 신청할 수 없습니다."),
     POST_ALREADY_PENDING(HttpStatus.CONFLICT, "이미 신청했습니다."),
@@ -39,9 +43,11 @@ public enum ErrorCode {
     NO_UPDATE_PERMISSION(HttpStatus.FORBIDDEN, "수정 권한이 없습니다."),
     CANNOT_PARTICIPATE_POST(HttpStatus.FORBIDDEN,"참가 인원이 모두 찼습니다."),
 
-    // 게시물 좋아요 관련 에러
-    POSTLIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "게시물 좋아요를 찾을 수 없습니다"),
-    ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 누른 게시글입니다."),
+    // 게시물 신청 조건 불일치
+    AGE_LIMIT_NOT_SATISFIED(HttpStatus.FORBIDDEN, "요구하는 연령대 조건에 부합하지 않습니다."),
+    GENDER_LIMIT_NOT_SATISFIED(HttpStatus.FORBIDDEN, "요구하는 성별 조건에 부합하지 않습니다."),
+    JOB_CATEGORY_LIMIT_NOT_SATISFIED(HttpStatus.FORBIDDEN, "요구하는 직군 조건에 부합하지 않습니다."),
+
 
     // 사용자 리뷰 관련 에러
     CANNOT_REVIEW_SELF(HttpStatus.BAD_REQUEST, "리뷰 작성자는 본인을 평가할 수 없습니다."),

--- a/src/main/java/org/example/pdnight/domain/common/enums/ErrorCode.java
+++ b/src/main/java/org/example/pdnight/domain/common/enums/ErrorCode.java
@@ -48,6 +48,10 @@ public enum ErrorCode {
     GENDER_LIMIT_NOT_SATISFIED(HttpStatus.FORBIDDEN, "요구하는 성별 조건에 부합하지 않습니다."),
     JOB_CATEGORY_LIMIT_NOT_SATISFIED(HttpStatus.FORBIDDEN, "요구하는 직군 조건에 부합하지 않습니다."),
 
+    //초대 관련 에러
+    INVITE_ALREADY_EXISTS(HttpStatus.CONFLICT,"이미 초대 한 사람입니다."),
+    INVITE_NOT_FOUND(HttpStatus.NOT_FOUND,"초대가 존재하지 않습니다."),
+    INVITE_UNAUTHORIZED(HttpStatus.FORBIDDEN,"본인이 한 초대가 아닙니다."),
 
     // 사용자 리뷰 관련 에러
     CANNOT_REVIEW_SELF(HttpStatus.BAD_REQUEST, "리뷰 작성자는 본인을 평가할 수 없습니다."),

--- a/src/main/java/org/example/pdnight/domain/common/enums/JobCategory.java
+++ b/src/main/java/org/example/pdnight/domain/common/enums/JobCategory.java
@@ -18,5 +18,6 @@ public enum JobCategory {
     SYSTEM_ENGINEER,
     GAME_DEVELOPER,
     EMBEDDED_ENGINEER,
-    ETC // 기타
+    ETC, // 기타
+    ALL
 }

--- a/src/main/java/org/example/pdnight/domain/common/enums/JoinStatus.java
+++ b/src/main/java/org/example/pdnight/domain/common/enums/JoinStatus.java
@@ -1,4 +1,4 @@
-package org.example.pdnight.domain.participant.enums;
+package org.example.pdnight.domain.common.enums;
 
 import org.example.pdnight.domain.common.exception.BaseException;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/org/example/pdnight/domain/invite/controller/InviteController.java
+++ b/src/main/java/org/example/pdnight/domain/invite/controller/InviteController.java
@@ -1,0 +1,43 @@
+package org.example.pdnight.domain.invite.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.common.dto.ApiResponse;
+import org.example.pdnight.domain.invite.dto.response.InviteResponseDto;
+import org.example.pdnight.domain.invite.service.InviteService;
+import org.example.pdnight.global.filter.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.parameters.P;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class InviteController {
+    private final InviteService inviteService;
+
+    @PostMapping("/post/{postId}/users/{userId}/invite")
+    public ResponseEntity<ApiResponse<InviteResponseDto>> inviteUser(
+            @PathVariable Long postId,
+            @PathVariable Long userId,
+            @AuthenticationPrincipal CustomUserDetails loginUser
+            ){
+        Long loginUserId = loginUser.getUserId();
+        InviteResponseDto responseDto = inviteService.createInvite(postId,userId,loginUserId);
+        URI location = URI.create("/api/posts/" + postId);
+        return ResponseEntity.created(location).body(ApiResponse.ok("초대가 완료되었습니다.",responseDto));
+    }
+
+    @DeleteMapping("/post/{postId}/users/{userId}/invite/{id}")
+    public ResponseEntity<?> deleteInvite(
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails loginUser
+    ){
+        Long loginUserId = loginUser.getUserId();
+
+        inviteService.deleteInvite(id,loginUserId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/org/example/pdnight/domain/invite/controller/InviteController.java
+++ b/src/main/java/org/example/pdnight/domain/invite/controller/InviteController.java
@@ -7,7 +7,6 @@ import org.example.pdnight.domain.invite.service.InviteService;
 import org.example.pdnight.global.filter.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
@@ -31,13 +30,14 @@ public class InviteController {
     }
 
     @DeleteMapping("/post/{postId}/users/{userId}/invite/{id}")
-    public ResponseEntity<?> deleteInvite(
+    public ResponseEntity<ApiResponse<?>> deleteInvite(
             @PathVariable Long id,
             @AuthenticationPrincipal CustomUserDetails loginUser
-    ){
+    ) {
         Long loginUserId = loginUser.getUserId();
 
-        inviteService.deleteInvite(id,loginUserId);
-        return ResponseEntity.noContent().build();
+        inviteService.deleteInvite(id, loginUserId);
+        return ResponseEntity.ok(ApiResponse.ok("초대가 삭제되었습니다.", null));
     }
+
 }

--- a/src/main/java/org/example/pdnight/domain/invite/dto/response/InviteResponseDto.java
+++ b/src/main/java/org/example/pdnight/domain/invite/dto/response/InviteResponseDto.java
@@ -1,0 +1,36 @@
+package org.example.pdnight.domain.invite.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.pdnight.domain.invite.entity.Invite;
+import org.example.pdnight.domain.post.entity.Post;
+import org.example.pdnight.domain.user.entity.User;
+
+@Getter
+public class InviteResponseDto {
+    private Long id;
+    private Long inviteeId;
+    private String inviteeNickName;
+    private Long postId;
+    private String postTitle;
+
+    public InviteResponseDto(Invite invite){
+        this.id = invite.getId();
+        this.inviteeId = invite.getInvitee().getId();
+        this.inviteeNickName = invite.getInvitee().getNickname();
+        this.postId = invite.getPost().getId();
+        this.postTitle = invite.getPost().getTitle();
+    };
+
+    @QueryProjection
+    public InviteResponseDto(
+            Long id,Long inviteeId,String inviteeNickName,Long postId,String postTitle)
+    {
+        this.id = id;
+        this.inviteeId = inviteeId;
+        this.inviteeNickName = inviteeNickName;
+        this.postId = postId;
+        this.postTitle = postTitle;
+    }
+}

--- a/src/main/java/org/example/pdnight/domain/invite/entity/Invite.java
+++ b/src/main/java/org/example/pdnight/domain/invite/entity/Invite.java
@@ -1,0 +1,49 @@
+package org.example.pdnight.domain.invite.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.example.pdnight.domain.common.entity.Timestamped;
+import org.example.pdnight.domain.common.enums.JoinStatus;
+import org.example.pdnight.domain.post.entity.Post;
+import org.example.pdnight.domain.user.entity.User;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "invites")
+@AllArgsConstructor
+@NoArgsConstructor
+public class Invite extends Timestamped {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "inviter_id")
+    private User inviter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "invitee_id")
+    private User invitee;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Column(name = "status")
+    private JoinStatus status = JoinStatus.PENDING;
+
+    private Invite(User inviter,User invitee,Post post){
+        this.inviter = inviter;
+        this.invitee = invitee;
+        this.post = post;
+    }
+
+    public static Invite create(User inviter, User invitee, Post post) {
+        return new Invite(invitee, inviter, post);
+    }
+
+}

--- a/src/main/java/org/example/pdnight/domain/invite/repository/InviteRepository.java
+++ b/src/main/java/org/example/pdnight/domain/invite/repository/InviteRepository.java
@@ -1,0 +1,12 @@
+package org.example.pdnight.domain.invite.repository;
+
+import org.example.pdnight.domain.common.enums.JoinStatus;
+import org.example.pdnight.domain.invite.entity.Invite;
+import org.example.pdnight.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InviteRepository extends JpaRepository<Invite,Long> {
+    Boolean existsByPostIdAndInviteeIdAndInviterId(Long postId,Long inviteeId, Long inviterId);
+
+    void deleteAllByPostAndStatus(Post post, JoinStatus joinStatus);
+}

--- a/src/main/java/org/example/pdnight/domain/invite/repository/InviteRepositoryQuery.java
+++ b/src/main/java/org/example/pdnight/domain/invite/repository/InviteRepositoryQuery.java
@@ -2,9 +2,12 @@ package org.example.pdnight.domain.invite.repository;
 
 import org.example.pdnight.domain.invite.dto.response.InviteResponseDto;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface InviteRepositoryQuery {
-    Page<InviteResponseDto> getMyInvited(Long userId);
+    Page<InviteResponseDto> getMyInvited(Long userId, Pageable pageable);
+
+    Page<InviteResponseDto> getMyInvite(Long userId, Pageable pageable);
 }

--- a/src/main/java/org/example/pdnight/domain/invite/repository/InviteRepositoryQuery.java
+++ b/src/main/java/org/example/pdnight/domain/invite/repository/InviteRepositoryQuery.java
@@ -1,0 +1,10 @@
+package org.example.pdnight.domain.invite.repository;
+
+import org.example.pdnight.domain.invite.dto.response.InviteResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface InviteRepositoryQuery {
+    Page<InviteResponseDto> getMyInvited(Long userId);
+}

--- a/src/main/java/org/example/pdnight/domain/invite/repository/InviteRepositoryQueryImpl.java
+++ b/src/main/java/org/example/pdnight/domain/invite/repository/InviteRepositoryQueryImpl.java
@@ -1,0 +1,21 @@
+package org.example.pdnight.domain.invite.repository;
+
+import org.example.pdnight.domain.invite.dto.response.InviteResponseDto;
+import org.example.pdnight.domain.invite.entity.QInvite;
+import org.example.pdnight.domain.post.entity.QPost;
+import org.example.pdnight.domain.user.entity.QUser;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InviteRepositoryQueryImpl implements InviteRepositoryQuery{
+    @Override
+    public Page<InviteResponseDto> getMyInvited(Long userId) {
+        QInvite invite = QInvite.invite;
+        QUser user= QUser.user;
+        QPost post = QPost.post;
+
+
+        return null;
+    }
+}

--- a/src/main/java/org/example/pdnight/domain/invite/repository/InviteRepositoryQueryImpl.java
+++ b/src/main/java/org/example/pdnight/domain/invite/repository/InviteRepositoryQueryImpl.java
@@ -1,21 +1,80 @@
 package org.example.pdnight.domain.invite.repository;
 
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
 import org.example.pdnight.domain.invite.dto.response.InviteResponseDto;
+import org.example.pdnight.domain.invite.dto.response.QInviteResponseDto;
 import org.example.pdnight.domain.invite.entity.QInvite;
 import org.example.pdnight.domain.post.entity.QPost;
 import org.example.pdnight.domain.user.entity.QUser;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@RequiredArgsConstructor
 public class InviteRepositoryQueryImpl implements InviteRepositoryQuery{
+    private final JPAQueryFactory queryFactory;
+
+    //내가 초대 받은 목록
     @Override
-    public Page<InviteResponseDto> getMyInvited(Long userId) {
+    public Page<InviteResponseDto> getMyInvited(Long userId, Pageable pageable) {
         QInvite invite = QInvite.invite;
-        QUser user= QUser.user;
+        QUser user = QUser.user;
         QPost post = QPost.post;
 
+        JPQLQuery<InviteResponseDto> query = queryFactory
+                .select(new QInviteResponseDto(
+                        invite.id,
+                        invite.invitee.id,
+                        invite.invitee.nickname,
+                        invite.post.id,
+                        invite.post.title
+                ))
+                .from(invite)
+                .join(invite.invitee, user).fetchJoin()
+                .join(invite.post, post).fetchJoin()
+                .where(invite.invitee.id.eq(userId)) // 내가 초대 받은 경우
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
 
-        return null;
+        JPQLQuery<Long> countQuery = queryFactory
+                .select(invite.count())
+                .from(invite)
+                .where(invite.invitee.id.eq(userId));
+
+        return PageableExecutionUtils.getPage(query.fetch(), pageable, countQuery::fetchOne);
+    }
+
+    //내가 초대 한 목록
+    @Override
+    public Page<InviteResponseDto> getMyInvite(Long userId, Pageable pageable) {
+        QInvite invite = QInvite.invite;
+        QUser user = QUser.user;
+        QPost post = QPost.post;
+
+        JPQLQuery<InviteResponseDto> query = queryFactory
+                .select(new QInviteResponseDto(
+                        invite.id,
+                        invite.invitee.id,
+                        invite.invitee.nickname,
+                        invite.post.id,
+                        invite.post.title
+                ))
+                .from(invite)
+                .join(invite.invitee, user).fetchJoin()
+                .join(invite.post, post).fetchJoin()
+                .where(invite.inviter.id.eq(userId)) // 내가 초대한 경우
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        JPQLQuery<Long> countQuery = queryFactory
+                .select(invite.count())
+                .from(invite)
+                .where(invite.inviter.id.eq(userId));
+
+        return PageableExecutionUtils.getPage(query.fetch(), pageable, countQuery::fetchOne);
     }
 }

--- a/src/main/java/org/example/pdnight/domain/invite/service/InviteService.java
+++ b/src/main/java/org/example/pdnight/domain/invite/service/InviteService.java
@@ -13,6 +13,7 @@ import org.example.pdnight.domain.post.service.PostService;
 import org.example.pdnight.domain.user.entity.User;
 import org.example.pdnight.domain.user.service.UserService;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.Objects;
@@ -54,12 +55,21 @@ public class InviteService {
         inviteRepository.delete(invite);
     }
 
-    public PagedResponse<InviteResponseDto> getMyInvited(Long userId) {
-        Page<InviteResponseDto> inviteResponseDtos = inviteRepositoryQuery.getMyInvited(userId);
-        return null;
+    //내가 초대 받은 목록 조회
+    public PagedResponse<InviteResponseDto> getMyInvited(Long userId, Pageable pageable) {
+        Page<InviteResponseDto> inviteResponseDtos = inviteRepositoryQuery.getMyInvited(userId, pageable);
+        return PagedResponse.from(inviteResponseDtos);
+    }
+
+    //내가 초대 한 목록 조회
+    public PagedResponse<InviteResponseDto> getMyInvite(Long userId, Pageable pageable) {
+        Page<InviteResponseDto> inviteResponseDtos = inviteRepositoryQuery.getMyInvite(userId, pageable);
+        return PagedResponse.from(inviteResponseDtos);
     }
 
     public void deleteAllByPostAndStatus(Post post,JoinStatus joinStatus){
         inviteRepository.deleteAllByPostAndStatus(post, joinStatus);
     };
+
+
 }

--- a/src/main/java/org/example/pdnight/domain/invite/service/InviteService.java
+++ b/src/main/java/org/example/pdnight/domain/invite/service/InviteService.java
@@ -1,0 +1,65 @@
+package org.example.pdnight.domain.invite.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.common.dto.PagedResponse;
+import org.example.pdnight.domain.common.enums.JoinStatus;
+import org.example.pdnight.domain.common.exception.BaseException;
+import org.example.pdnight.domain.invite.dto.response.InviteResponseDto;
+import org.example.pdnight.domain.invite.entity.Invite;
+import org.example.pdnight.domain.invite.repository.InviteRepository;
+import org.example.pdnight.domain.invite.repository.InviteRepositoryQuery;
+import org.example.pdnight.domain.post.entity.Post;
+import org.example.pdnight.domain.post.service.PostService;
+import org.example.pdnight.domain.user.entity.User;
+import org.example.pdnight.domain.user.service.UserService;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+import static org.example.pdnight.domain.common.enums.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+public class InviteService {
+    private final InviteRepository inviteRepository;
+    private final InviteRepositoryQuery inviteRepositoryQuery;
+    private final PostService postService;
+    private final UserService userService;
+
+    public InviteResponseDto createInvite(Long postId, Long userId,Long loginUserId) {
+        Post postById = postService.getPostById(postId);
+        User inviteeById = userService.getUserById(userId);
+        User me = userService.getUserById(loginUserId);
+
+        Boolean inviteExists = inviteRepository.existsByPostIdAndInviteeIdAndInviterId(postId,userId,loginUserId);
+
+        if (inviteExists){
+            throw new BaseException(INVITE_ALREADY_EXISTS);
+        }
+        Invite invite = Invite.create(me, inviteeById,postById);
+
+        inviteRepository.save(invite);
+        return new InviteResponseDto(invite);
+    }
+
+    public void deleteInvite(Long inviteId, Long loginUserId) {
+        Invite invite = inviteRepository.findById(inviteId).orElseThrow(
+                () ->new BaseException(INVITE_NOT_FOUND));
+
+        if (!Objects.equals(invite.getInviter().getId(), loginUserId)) {
+            throw new BaseException(INVITE_UNAUTHORIZED);
+        }
+
+        inviteRepository.delete(invite);
+    }
+
+    public PagedResponse<InviteResponseDto> getMyInvited(Long userId) {
+        Page<InviteResponseDto> inviteResponseDtos = inviteRepositoryQuery.getMyInvited(userId);
+        return null;
+    }
+
+    public void deleteAllByPostAndStatus(Post post,JoinStatus joinStatus){
+        inviteRepository.deleteAllByPostAndStatus(post, joinStatus);
+    };
+}

--- a/src/main/java/org/example/pdnight/domain/participant/dto/response/ParticipantResponse.java
+++ b/src/main/java/org/example/pdnight/domain/participant/dto/response/ParticipantResponse.java
@@ -3,7 +3,7 @@ package org.example.pdnight.domain.participant.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import org.example.pdnight.domain.participant.enums.JoinStatus;
+import org.example.pdnight.domain.common.enums.JoinStatus;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/org/example/pdnight/domain/participant/entity/PostParticipant.java
+++ b/src/main/java/org/example/pdnight/domain/participant/entity/PostParticipant.java
@@ -5,7 +5,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.pdnight.domain.common.entity.Timestamped;
-import org.example.pdnight.domain.participant.enums.JoinStatus;
+import org.example.pdnight.domain.common.enums.JoinStatus;
 import org.example.pdnight.domain.post.entity.Post;
 import org.example.pdnight.domain.user.entity.User;
 

--- a/src/main/java/org/example/pdnight/domain/participant/entity/PostParticipant.java
+++ b/src/main/java/org/example/pdnight/domain/participant/entity/PostParticipant.java
@@ -39,6 +39,10 @@ public class PostParticipant extends Timestamped {
         return new PostParticipant(post, user, JoinStatus.PENDING);
     }
 
+    public static PostParticipant createIsFirst(Post post, User user) {
+        return new PostParticipant(post, user, JoinStatus.ACCEPTED);
+    }
+
     public void changeStatus(JoinStatus status) {
         this.status = status;
     }

--- a/src/main/java/org/example/pdnight/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/org/example/pdnight/domain/participant/repository/ParticipantRepository.java
@@ -16,4 +16,6 @@ public interface ParticipantRepository extends JpaRepository<PostParticipant, Lo
     List<PostParticipant> findByPostAndStatus(Post post, JoinStatus status);
 
     Page<PostParticipant> findByPostAndStatus(Post post, JoinStatus status, Pageable pageable);
+
+    int countByPostAndStatus(Post post, JoinStatus joinStatus);
 }

--- a/src/main/java/org/example/pdnight/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/org/example/pdnight/domain/participant/repository/ParticipantRepository.java
@@ -1,7 +1,7 @@
 package org.example.pdnight.domain.participant.repository;
 
 import org.example.pdnight.domain.participant.entity.PostParticipant;
-import org.example.pdnight.domain.participant.enums.JoinStatus;
+import org.example.pdnight.domain.common.enums.JoinStatus;
 import org.example.pdnight.domain.post.entity.Post;
 import org.example.pdnight.domain.user.entity.User;
 import org.springframework.data.domain.Page;

--- a/src/main/java/org/example/pdnight/domain/participant/service/ParticipantService.java
+++ b/src/main/java/org/example/pdnight/domain/participant/service/ParticipantService.java
@@ -3,12 +3,15 @@ package org.example.pdnight.domain.participant.service;
 import lombok.RequiredArgsConstructor;
 import org.example.pdnight.domain.common.dto.PagedResponse;
 import org.example.pdnight.domain.common.enums.ErrorCode;
+import org.example.pdnight.domain.common.enums.JobCategory;
 import org.example.pdnight.domain.common.exception.BaseException;
 import org.example.pdnight.domain.participant.dto.response.ParticipantResponse;
 import org.example.pdnight.domain.participant.entity.PostParticipant;
 import org.example.pdnight.domain.participant.enums.JoinStatus;
 import org.example.pdnight.domain.participant.repository.ParticipantRepository;
 import org.example.pdnight.domain.post.entity.Post;
+import org.example.pdnight.domain.post.enums.AgeLimit;
+import org.example.pdnight.domain.post.enums.Gender;
 import org.example.pdnight.domain.post.enums.PostStatus;
 import org.example.pdnight.domain.post.repository.PostRepository;
 import org.example.pdnight.domain.user.entity.User;
@@ -18,6 +21,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
 
 import static org.example.pdnight.domain.common.enums.ErrorCode.CANNOT_PARTICIPATE_POST;
 
@@ -30,32 +35,26 @@ public class ParticipantService {
     private final UserRepository userRepository;
     private final ParticipantRepository participantRepository;
 
-    private User getUser(Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
-    }
-
-    private Post getPost(Long postId) {
-        return postRepository.findById(postId)
-                .orElseThrow(() -> new BaseException(ErrorCode.POST_NOT_FOUND));
-    }
-
-    private Post getPostWithOpen(Long postId) {
-        return postRepository.findByIdAndStatus(postId, PostStatus.OPEN)
-                .orElseThrow(() -> new BaseException(ErrorCode.POST_NOT_FOUND));
-    }
-
-    private PostParticipant getParticipantByStatus(User user, Post post, JoinStatus pending) {
-        return participantRepository.findByUserAndPost(user, post).stream()
-                .filter(p -> p.getStatus().equals(pending))
-                .findFirst()
-                .orElse(null);
-    }
-
     private void validForCreateParticipant(User user, Post post) {
         // 신청 안됨 : 본인 게시글에 본인이 신청하는 경우
         if (post.getAuthor().equals(user)) {
             throw new BaseException(ErrorCode.CANNOT_PARTICIPATE_SELF);
+        }
+
+        //나이 조건 안 맞으면 신청 불가
+        AgeLimit userAgeLimit = determineAgeLimit(user.getAge());
+        if (post.getAgeLimit() != AgeLimit.ALL && post.getAgeLimit() != userAgeLimit) {
+            throw new BaseException(ErrorCode.AGE_LIMIT_NOT_SATISFIED);
+        }
+
+        //성별 조건 안 맞으면 신청 불가
+        if (post.getGenderLimit() != Gender.ALL && post.getGenderLimit() != user.getGender()) {
+            throw new BaseException(ErrorCode.GENDER_LIMIT_NOT_SATISFIED);
+        }
+
+        //직업군 조건 안 맞으면 신청 불가
+        if (post.getJobCategoryLimit() != JobCategory.ALL && post.getJobCategoryLimit() != user.getJobCategory()) {
+            throw new BaseException(ErrorCode.JOB_CATEGORY_LIMIT_NOT_SATISFIED);
         }
 
         // 신청 안됨 : 이미 신청함 - JoinStatus status 가 대기중 or 수락됨 인 경우
@@ -199,5 +198,37 @@ public class ParticipantService {
                 p.getCreatedAt(),
                 p.getUpdatedAt()
         )));
+    }
+
+    // 이하 헬퍼 메서드
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private Post getPost(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new BaseException(ErrorCode.POST_NOT_FOUND));
+    }
+
+    private Post getPostWithOpen(Long postId) {
+        return postRepository.findByIdAndStatus(postId, PostStatus.OPEN)
+                .orElseThrow(() -> new BaseException(ErrorCode.POST_NOT_FOUND));
+    }
+
+    private PostParticipant getParticipantByStatus(User user, Post post, JoinStatus pending) {
+        return participantRepository.findByUserAndPost(user, post).stream()
+                .filter(p -> p.getStatus().equals(pending))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public static AgeLimit determineAgeLimit(Long age) {
+        if (age >= 20 && age < 30) return AgeLimit.AGE_20S;
+        else if (age >= 30 && age < 40) return AgeLimit.AGE_30S;
+        else if (age >= 40 && age < 50) return AgeLimit.AGE_40S;
+        else if (age >= 50) return AgeLimit.AGE_50S;
+        return AgeLimit.ALL;
     }
 }

--- a/src/main/java/org/example/pdnight/domain/post/controller/AdminPostController.java
+++ b/src/main/java/org/example/pdnight/domain/post/controller/AdminPostController.java
@@ -1,0 +1,28 @@
+package org.example.pdnight.domain.post.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.common.dto.ApiResponse;
+import org.example.pdnight.domain.post.service.AdminPostService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/api/posts")
+@RequiredArgsConstructor
+public class AdminPostController {
+
+    private final AdminPostService postService;
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deletePost(
+            @PathVariable Long id
+    ) {
+        postService.deletePostById(id);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.ok("게시글이 삭제되었습니다.", null));
+    }
+}

--- a/src/main/java/org/example/pdnight/domain/post/controller/PostController.java
+++ b/src/main/java/org/example/pdnight/domain/post/controller/PostController.java
@@ -7,6 +7,7 @@ import org.example.pdnight.domain.post.dto.request.PostRequestDto;
 import org.example.pdnight.domain.post.dto.request.PostStatusRequestDto;
 import org.example.pdnight.domain.post.dto.request.PostUpdateRequestDto;
 import org.example.pdnight.domain.post.dto.response.PostResponseDto;
+import org.example.pdnight.domain.post.dto.response.PostResponseWithApplyStatusDto;
 import org.example.pdnight.domain.post.enums.AgeLimit;
 import org.example.pdnight.domain.post.enums.Gender;
 import org.example.pdnight.domain.post.service.PostService;
@@ -47,7 +48,7 @@ public class PostController {
 	}
 
 	@GetMapping("/{id}")
-	public ResponseEntity<ApiResponse<PostResponseDto>> getPostById(@PathVariable Long id) {
+	public ResponseEntity<ApiResponse<PostResponseWithApplyStatusDto>> getPostById(@PathVariable Long id) {
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(ApiResponse.ok("게시글이 조회되었습니다.", postService.findOpenedPost(id)));
 	}
@@ -64,7 +65,7 @@ public class PostController {
 	}
 
 	@GetMapping
-	public ResponseEntity<ApiResponse<PagedResponse<PostResponseDto>>> searchPosts(
+	public ResponseEntity<ApiResponse<PagedResponse<PostResponseWithApplyStatusDto>>> searchPosts(
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size,
 		@RequestParam(defaultValue = "1") Integer maxParticipants,
@@ -74,7 +75,7 @@ public class PostController {
 	) {
 		Pageable pageable = PageRequest.of(page, size);
 
-		PagedResponse<PostResponseDto> pagedResponse = PagedResponse.from(
+		PagedResponse<PostResponseWithApplyStatusDto> pagedResponse = PagedResponse.from(
 			postService.getPostDtosBySearch(pageable, maxParticipants, ageLimit, jobCategoryLimit, genderLimit));
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(ApiResponse.ok("게시글 목록이 조회되었습니다.", pagedResponse));
@@ -102,6 +103,21 @@ public class PostController {
 		PostResponseDto updatedPost = postService.changeStatus(userId, id, requestDto);
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(ApiResponse.ok("게시글 상태가 수정되었습니다.", updatedPost));
+	}
+
+
+	//추천 게시물 조회
+	@GetMapping("/suggestedPosts")
+	public ResponseEntity<ApiResponse<PagedResponse<PostResponseWithApplyStatusDto>>> suggestedPosts(
+			@RequestParam(defaultValue = "0") int page,
+			@RequestParam(defaultValue = "10") int size,
+			@AuthenticationPrincipal CustomUserDetails loginUser
+	) {
+		Pageable pageable = PageRequest.of(page, size);
+		Long userId = loginUser.getUserId();
+		PagedResponse<PostResponseWithApplyStatusDto> pagedResponse = postService.getSuggestedPosts(userId,pageable);
+		return ResponseEntity.status(HttpStatus.OK)
+				.body(ApiResponse.ok("게시글 목록이 조회되었습니다.", pagedResponse));
 	}
 
 }

--- a/src/main/java/org/example/pdnight/domain/post/dto/response/PostResponseWithApplyStatusDto.java
+++ b/src/main/java/org/example/pdnight/domain/post/dto/response/PostResponseWithApplyStatusDto.java
@@ -1,0 +1,103 @@
+package org.example.pdnight.domain.post.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.pdnight.domain.common.enums.JobCategory;
+import org.example.pdnight.domain.post.entity.Post;
+import org.example.pdnight.domain.post.enums.AgeLimit;
+import org.example.pdnight.domain.post.enums.Gender;
+import org.example.pdnight.domain.post.enums.PostStatus;
+
+import java.time.LocalDateTime;
+
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@NoArgsConstructor(force = true)
+public class PostResponseWithApplyStatusDto {
+    private final Long postId;
+    private final Long authorId;
+    private final String title;
+    private final LocalDateTime timeSlot;
+    private final String publicContent;
+    private final String privateContent;
+    private final PostStatus status;
+    private final Integer maxParticipants;
+    private final Gender genderLimit;
+    private final JobCategory jobCategoryLimit;
+    private final AgeLimit ageLimit;
+    private final Long appliedCount;
+    private final Long confirmedCount;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public PostResponseWithApplyStatusDto(Post post, Long appliedCount, Long confirmedCount, Long appliedCount1, Long confirmedCount1) {
+        this.postId = post.getId();
+        this.authorId = post.getAuthor().getId();
+        this.title = post.getTitle();
+        this.timeSlot = post.getTimeSlot();
+        this.publicContent = post.getPublicContent();
+        this.privateContent = post.getPrivateContent();
+        this.status = post.getStatus();
+        this.maxParticipants = post.getMaxParticipants();
+        this.genderLimit = post.getGenderLimit();
+        this.jobCategoryLimit = post.getJobCategoryLimit();
+        this.ageLimit = post.getAgeLimit();
+        this.createdAt = post.getCreatedAt();
+        this.updatedAt = post.getUpdatedAt();
+        this.appliedCount = appliedCount;
+        this.confirmedCount = confirmedCount;
+    }
+
+    @QueryProjection
+    public PostResponseWithApplyStatusDto(
+            Long id,
+            Long authorId,
+            String title,
+            LocalDateTime timeSlot,
+            String publicContent,
+            String privateContent,
+            PostStatus status,
+            Integer maxParticipants,
+            Gender genderLimit,
+            JobCategory jobCategoryLimit,
+            AgeLimit ageLimit, Long appliedCount, Long confirmedCount,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        this.postId = id;
+        this.authorId = authorId;
+        this.title = title;
+        this.timeSlot = timeSlot;
+        this.publicContent = publicContent;
+        this.privateContent = privateContent;
+        this.status = status;
+        this.maxParticipants = maxParticipants;
+        this.genderLimit = genderLimit;
+        this.jobCategoryLimit = jobCategoryLimit;
+        this.ageLimit = ageLimit;
+        this.appliedCount = appliedCount;
+        this.confirmedCount = confirmedCount;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static PostResponseDto toDto(Post post){
+        return new PostResponseDto(
+                post.getId(),
+                post.getAuthor().getId(),
+                post.getTitle(),
+                post.getTimeSlot(),
+                post.getPublicContent(),
+                post.getPrivateContent(),
+                post.getStatus(),
+                post.getMaxParticipants(),
+                post.getGenderLimit(),
+                post.getJobCategoryLimit(),
+                post.getAgeLimit(),
+                post.getCreatedAt(),
+                post.getUpdatedAt());
+    }
+}

--- a/src/main/java/org/example/pdnight/domain/post/entity/Post.java
+++ b/src/main/java/org/example/pdnight/domain/post/entity/Post.java
@@ -56,6 +56,9 @@ public class Post extends Timestamped {
     @Enumerated(EnumType.STRING)
     private AgeLimit ageLimit;
 
+    @Column(nullable = false)
+    private Boolean isFirstCome = false;
+
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostLike> postLikes = new ArrayList<>();

--- a/src/main/java/org/example/pdnight/domain/post/entity/Post.java
+++ b/src/main/java/org/example/pdnight/domain/post/entity/Post.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.pdnight.domain.common.entity.Timestamped;
+import org.example.pdnight.domain.invite.entity.Invite;
 import org.example.pdnight.domain.post.enums.AgeLimit;
 import org.example.pdnight.domain.post.enums.Gender;
 import org.example.pdnight.domain.common.enums.JobCategory;
@@ -55,6 +56,10 @@ public class Post extends Timestamped {
 
     @Enumerated(EnumType.STRING)
     private AgeLimit ageLimit;
+
+    // 게시물 삭제 되면 알아서 invite 삭제 되도록
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Invite> invites = new ArrayList<>();
 
     @Column(nullable = false)
     private Boolean isFirstCome = false;

--- a/src/main/java/org/example/pdnight/domain/post/enums/AgeLimit.java
+++ b/src/main/java/org/example/pdnight/domain/post/enums/AgeLimit.java
@@ -1,5 +1,5 @@
 package org.example.pdnight.domain.post.enums;
 
 public enum AgeLimit {
-    AGE_20S, AGE_30S, AGE_40S
+    AGE_20S, AGE_30S, AGE_40S, AGE_50S ,ALL
 }

--- a/src/main/java/org/example/pdnight/domain/post/enums/Gender.java
+++ b/src/main/java/org/example/pdnight/domain/post/enums/Gender.java
@@ -1,5 +1,5 @@
 package org.example.pdnight.domain.post.enums;
 
 public enum Gender {
-    MALE, FEMALE
+    MALE, FEMALE, ALL
 }

--- a/src/main/java/org/example/pdnight/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/example/pdnight/domain/post/repository/PostRepository.java
@@ -12,17 +12,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryQuery {
+public interface PostRepository extends JpaRepository<Post, Long>{
 	//상태값 조건 쿼리메서드
 	Optional<Post> findByIdAndStatus(Long id, PostStatus status);
-
-	@Override
-	Page<PostResponseDto> findPostDtosBySearch(
-		Pageable pageable,
-		Integer maxParticipants,
-		AgeLimit ageLimit,
-		JobCategory jobCategoryLimit,
-		Gender genderLimit
-	);
 
 }

--- a/src/main/java/org/example/pdnight/domain/post/repository/PostRepositoryQuery.java
+++ b/src/main/java/org/example/pdnight/domain/post/repository/PostRepositoryQuery.java
@@ -2,6 +2,7 @@ package org.example.pdnight.domain.post.repository;
 
 import org.example.pdnight.domain.participant.enums.JoinStatus;
 import org.example.pdnight.domain.post.dto.response.PostResponseDto;
+import org.example.pdnight.domain.post.dto.response.PostResponseWithApplyStatusDto;
 import org.example.pdnight.domain.post.entity.Post;
 import org.example.pdnight.domain.user.dto.response.PostWithJoinStatusAndAppliedAtResponseDto;
 import org.example.pdnight.domain.common.enums.JobCategory;
@@ -15,12 +16,16 @@ import org.springframework.stereotype.Repository;
 
 public interface PostRepositoryQuery {
 
-    Page<Post> getMyLikePost(Long userId, Pageable pageable);
+	Page<PostResponseWithApplyStatusDto> getOpenedPosts(Long userId, Pageable pageable);
+
+	PostResponseWithApplyStatusDto getOpenedPostById(Long postId);
+
+	Page<PostResponseWithApplyStatusDto> getMyLikePost(Long userId, Pageable pageable);
 
     Page<PostWithJoinStatusAndAppliedAtResponseDto> getConfirmedPost(Long userId, JoinStatus joinStatus, Pageable pageable);
 
 	//필터링 조건에 따른 동적쿼리 프로젝션으로 DTO 반환
-	Page<PostResponseDto> findPostDtosBySearch(
+	Page<PostResponseWithApplyStatusDto> findPostDtosBySearch(
 		Pageable pageable,
 		Integer maxParticipants,
 		AgeLimit ageLimit,
@@ -28,5 +33,7 @@ public interface PostRepositoryQuery {
 		Gender genderLimit
 	);
   
-    Page<PostResponseDto> getWrittenPost(Long userId, Pageable pageable);
+    Page<PostResponseWithApplyStatusDto> getWrittenPost(Long userId, Pageable pageable);
+
+	Page<PostResponseWithApplyStatusDto> getSuggestedPost(Long id,Pageable pageable);
 }

--- a/src/main/java/org/example/pdnight/domain/post/repository/PostRepositoryQuery.java
+++ b/src/main/java/org/example/pdnight/domain/post/repository/PostRepositoryQuery.java
@@ -1,18 +1,13 @@
 package org.example.pdnight.domain.post.repository;
 
-import org.example.pdnight.domain.participant.enums.JoinStatus;
-import org.example.pdnight.domain.post.dto.response.PostResponseDto;
+import org.example.pdnight.domain.common.enums.JoinStatus;
 import org.example.pdnight.domain.post.dto.response.PostResponseWithApplyStatusDto;
-import org.example.pdnight.domain.post.entity.Post;
 import org.example.pdnight.domain.user.dto.response.PostWithJoinStatusAndAppliedAtResponseDto;
 import org.example.pdnight.domain.common.enums.JobCategory;
-import org.example.pdnight.domain.post.dto.response.PostResponseDto;
 import org.example.pdnight.domain.post.enums.AgeLimit;
 import org.example.pdnight.domain.post.enums.Gender;
-import org.example.pdnight.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
 
 public interface PostRepositoryQuery {
 

--- a/src/main/java/org/example/pdnight/domain/post/repository/PostRepositoryQueryImpl.java
+++ b/src/main/java/org/example/pdnight/domain/post/repository/PostRepositoryQueryImpl.java
@@ -2,23 +2,16 @@ package org.example.pdnight.domain.post.repository;
 
 import com.querydsl.core.BooleanBuilder;
 
-import static org.example.pdnight.domain.post.entity.QPost.post;
-
 import java.util.List;
 import java.util.Optional;
 
-import com.querydsl.core.types.dsl.BooleanExpression;
-
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 import org.example.pdnight.domain.participant.entity.QPostParticipant;
-import org.example.pdnight.domain.participant.enums.JoinStatus;
+import org.example.pdnight.domain.common.enums.JoinStatus;
 import org.example.pdnight.domain.post.dto.response.PostResponseWithApplyStatusDto;
-import org.example.pdnight.domain.post.dto.response.QPostResponseDto;
 import org.example.pdnight.domain.post.dto.response.QPostResponseWithApplyStatusDto;
-import org.example.pdnight.domain.post.entity.Post;
 import org.example.pdnight.domain.post.entity.QPost;
 import org.example.pdnight.domain.post.repository.QueryDslHelper.QuerydslExpressionHelper;
 import org.example.pdnight.domain.postLike.entity.QPostLike;
@@ -26,7 +19,6 @@ import org.example.pdnight.domain.user.dto.response.PostWithJoinStatusAndApplied
 import org.example.pdnight.domain.user.dto.response.QPostWithJoinStatusAndAppliedAtResponseDto;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.example.pdnight.domain.common.enums.JobCategory;
-import org.example.pdnight.domain.post.dto.response.PostResponseDto;
 import org.example.pdnight.domain.post.enums.AgeLimit;
 import org.example.pdnight.domain.post.enums.Gender;
 import org.example.pdnight.domain.post.enums.PostStatus;

--- a/src/main/java/org/example/pdnight/domain/post/repository/QueryDslHelper/QuerydslExpressionHelper.java
+++ b/src/main/java/org/example/pdnight/domain/post/repository/QueryDslHelper/QuerydslExpressionHelper.java
@@ -3,7 +3,7 @@ package org.example.pdnight.domain.post.repository.QueryDslHelper;
 import com.querydsl.core.types.Expression;
 import com.querydsl.jpa.JPAExpressions;
 import org.example.pdnight.domain.participant.entity.QPostParticipant;
-import org.example.pdnight.domain.participant.enums.JoinStatus;
+import org.example.pdnight.domain.common.enums.JoinStatus;
 import org.example.pdnight.domain.post.entity.QPost;
 
 public class QuerydslExpressionHelper {

--- a/src/main/java/org/example/pdnight/domain/post/repository/QueryDslHelper/QuerydslExpressionHelper.java
+++ b/src/main/java/org/example/pdnight/domain/post/repository/QueryDslHelper/QuerydslExpressionHelper.java
@@ -1,0 +1,27 @@
+package org.example.pdnight.domain.post.repository.QueryDslHelper;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.jpa.JPAExpressions;
+import org.example.pdnight.domain.participant.entity.QPostParticipant;
+import org.example.pdnight.domain.participant.enums.JoinStatus;
+import org.example.pdnight.domain.post.entity.QPost;
+
+public class QuerydslExpressionHelper {
+
+    private static final QPostParticipant participant = QPostParticipant.postParticipant;
+
+    public static Expression<Long> participantCount(QPost post) {
+        return JPAExpressions
+                .select(participant.count())
+                .from(participant)
+                .where(participant.post.eq(post));
+    }
+
+    public static Expression<Long> acceptedParticipantCount(QPost post) {
+        return JPAExpressions
+                .select(participant.count())
+                .from(participant)
+                .where(participant.post.eq(post)
+                        .and(participant.status.eq(JoinStatus.ACCEPTED)));
+    }
+}

--- a/src/main/java/org/example/pdnight/domain/post/service/AdminPostService.java
+++ b/src/main/java/org/example/pdnight/domain/post/service/AdminPostService.java
@@ -1,0 +1,31 @@
+package org.example.pdnight.domain.post.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.common.enums.ErrorCode;
+import org.example.pdnight.domain.common.exception.BaseException;
+import org.example.pdnight.domain.post.entity.Post;
+import org.example.pdnight.domain.post.repository.PostRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminPostService {
+
+    private final PostRepository postRepository;
+
+    @Transactional
+    public void deletePostById(Long id) {
+        Post foundPost = getPostOrThrow(postRepository.findById(id));
+
+        foundPost.unlinkReviews();
+        postRepository.delete(foundPost);
+    }
+
+    //이하 헬퍼 메서드
+    private Post getPostOrThrow(Optional<Post> post) {
+        return post.orElseThrow(() -> new BaseException(ErrorCode.POST_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/example/pdnight/domain/post/service/PostService.java
+++ b/src/main/java/org/example/pdnight/domain/post/service/PostService.java
@@ -6,7 +6,7 @@ import org.example.pdnight.domain.common.dto.PagedResponse;
 import org.example.pdnight.domain.common.enums.ErrorCode;
 import org.example.pdnight.domain.common.enums.JobCategory;
 import org.example.pdnight.domain.common.exception.BaseException;
-import org.example.pdnight.domain.participant.enums.JoinStatus;
+import org.example.pdnight.domain.common.enums.JoinStatus;
 import org.example.pdnight.domain.post.dto.request.PostRequestDto;
 import org.example.pdnight.domain.post.dto.request.PostStatusRequestDto;
 import org.example.pdnight.domain.post.dto.request.PostUpdateRequestDto;
@@ -15,6 +15,7 @@ import org.example.pdnight.domain.post.dto.response.PostResponseWithApplyStatusD
 import org.example.pdnight.domain.post.entity.Post;
 import org.example.pdnight.domain.post.enums.AgeLimit;
 import org.example.pdnight.domain.post.enums.Gender;
+import org.example.pdnight.domain.post.enums.PostStatus;
 import org.example.pdnight.domain.post.repository.PostRepository;
 import org.example.pdnight.domain.post.repository.PostRepositoryQuery;
 import org.example.pdnight.domain.user.dto.response.PostWithJoinStatusAndAppliedAtResponseDto;
@@ -72,6 +73,7 @@ public class PostService {
 		postRepository.delete(foundPost);
 	}
 
+	//게시물 조건 검색
 	@Transactional(readOnly = true)
 	public Page<PostResponseWithApplyStatusDto> getPostDtosBySearch(
 		Pageable pageable,
@@ -135,6 +137,11 @@ public class PostService {
 	public PagedResponse<PostResponseWithApplyStatusDto> getSuggestedPosts(Long id,Pageable pageable) {
 		Page<PostResponseWithApplyStatusDto> suggestedPost = PostRepositoryQuery.getSuggestedPost(id,pageable);
 		return PagedResponse.from(suggestedPost);
+	}
+
+	public Post getPostById(Long id){
+		Optional<Post> byIdAndStatus = postRepository.findByIdAndStatus(id, PostStatus.OPEN);
+		return getPostOrThrow(byIdAndStatus);
 	}
 
 	//이하 헬퍼 메서드

--- a/src/main/java/org/example/pdnight/domain/post/service/PostService.java
+++ b/src/main/java/org/example/pdnight/domain/post/service/PostService.java
@@ -35,7 +35,6 @@ public class PostService {
 	private final UserRepository userRepository;
 	private final PostRepositoryQuery PostRepositoryQuery;
 
-
 	//포스트 작성
 	@Transactional
 	public PostResponseDto createPost(Long userId, PostRequestDto request) {

--- a/src/main/java/org/example/pdnight/domain/review/controller/ReviewController.java
+++ b/src/main/java/org/example/pdnight/domain/review/controller/ReviewController.java
@@ -42,4 +42,26 @@ public class ReviewController {
 
         return ResponseEntity.ok(ApiResponse.ok("사용자가 받은 리뷰 리스트 조회 성공.",reviewService.getReceivedReviewsByUser(userId, pageable)));
     }
+
+    //내가 받은 리뷰 리스트 조회
+    @GetMapping("api/users/my/review")
+    public ResponseEntity<ApiResponse<?>> getMyReviews(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+        Long myId = userDetails.getUserId();
+        return ResponseEntity.ok(ApiResponse.ok("사용자가 받은 리뷰 리스트 조회 성공.",reviewService.getReceivedReviewsByUser(myId, pageable)));
+    }
+
+    //내가 받은 리뷰 리스트 조회
+    @GetMapping("api/users/my/writtenReview")
+    public ResponseEntity<ApiResponse<?>> getMyWrittenReviews(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+        Long myId = userDetails.getUserId();
+        return ResponseEntity.ok(ApiResponse.ok("사용자가 받은 리뷰 리스트 조회 성공.",reviewService.getWrittenReviewsByUser(myId, pageable)));
+    }
 }

--- a/src/main/java/org/example/pdnight/domain/review/controller/ReviewController.java
+++ b/src/main/java/org/example/pdnight/domain/review/controller/ReviewController.java
@@ -6,13 +6,13 @@ import org.example.pdnight.domain.review.dto.request.ReviewRequestDto;
 import org.example.pdnight.domain.review.dto.response.ReviewResponseDto;
 import org.example.pdnight.domain.review.service.ReviewService;
 import org.example.pdnight.global.filter.CustomUserDetails;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,5 +29,17 @@ public class ReviewController {
         ReviewResponseDto response = reviewService.createReview(userDetails.getUserId(), ratedUserId, postId, requestDto);
 
         return ResponseEntity.ok(ApiResponse.ok("리뷰가 등록되었습니다.", response));
+    }
+
+    //사용자가 받은 리뷰 리스트 조회
+    @GetMapping("api/users/{userId}/review")
+    public ResponseEntity<ApiResponse<?>> getReviews(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("userId") Long userId,
+            @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+
+        return ResponseEntity.ok(ApiResponse.ok("사용자가 받은 리뷰 리스트 조회 성공.",reviewService.getReceivedReviewsByUser(userId, pageable)));
     }
 }

--- a/src/main/java/org/example/pdnight/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/org/example/pdnight/domain/review/repository/ReviewRepository.java
@@ -11,4 +11,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     boolean existsByReviewerAndRatedUserAndPost(User reviewer, User ratedUser, Post post);
 
     Page<Review> findByRatedUser(User ratedUser, Pageable pageable);
+
+    Page<Review> findByReviewer(User reviewer, Pageable pageable);
 }

--- a/src/main/java/org/example/pdnight/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/org/example/pdnight/domain/review/repository/ReviewRepository.java
@@ -3,8 +3,12 @@ package org.example.pdnight.domain.review.repository;
 import org.example.pdnight.domain.post.entity.Post;
 import org.example.pdnight.domain.review.entity.Review;
 import org.example.pdnight.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     boolean existsByReviewerAndRatedUserAndPost(User reviewer, User ratedUser, Post post);
+
+    Page<Review> findByRatedUser(User ratedUser, Pageable pageable);
 }

--- a/src/main/java/org/example/pdnight/domain/review/service/ReviewService.java
+++ b/src/main/java/org/example/pdnight/domain/review/service/ReviewService.java
@@ -51,7 +51,7 @@ public class ReviewService {
         return new ReviewResponseDto(review);
     }
 
-    // 사용자의 리뷰 리스트 조회
+    // 사용자의 받은 리뷰 리스트 조회
     public PagedResponse<ReviewResponseDto> getReceivedReviewsByUser(Long userId, Pageable pageable) {
 
         User ratedUser = userRepository.findById(userId)
@@ -62,4 +62,13 @@ public class ReviewService {
         return PagedResponse.from(reviews.map(ReviewResponseDto::new));
     }
 
+    // 사용자의 작성한 리뷰 리스트 조회
+    public PagedResponse<ReviewResponseDto> getWrittenReviewsByUser(Long userId, Pageable pageable) {
+        User ratedUser = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
+
+        Page<Review> reviews = reviewRepository.findByReviewer(ratedUser, pageable);
+
+        return PagedResponse.from(reviews.map(ReviewResponseDto::new));
+    }
 }

--- a/src/main/java/org/example/pdnight/domain/review/service/ReviewService.java
+++ b/src/main/java/org/example/pdnight/domain/review/service/ReviewService.java
@@ -1,6 +1,7 @@
 package org.example.pdnight.domain.review.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.common.dto.PagedResponse;
 import org.example.pdnight.domain.common.enums.ErrorCode;
 import org.example.pdnight.domain.common.exception.BaseException;
 import org.example.pdnight.domain.post.entity.Post;
@@ -11,6 +12,8 @@ import org.example.pdnight.domain.review.entity.Review;
 import org.example.pdnight.domain.review.repository.ReviewRepository;
 import org.example.pdnight.domain.user.entity.User;
 import org.example.pdnight.domain.user.repository.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,4 +50,16 @@ public class ReviewService {
 
         return new ReviewResponseDto(review);
     }
+
+    // 사용자의 리뷰 리스트 조회
+    public PagedResponse<ReviewResponseDto> getReceivedReviewsByUser(Long userId, Pageable pageable) {
+
+        User ratedUser = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
+
+        Page<Review> reviews = reviewRepository.findByRatedUser(ratedUser, pageable);
+
+        return PagedResponse.from(reviews.map(ReviewResponseDto::new));
+    }
+
 }

--- a/src/main/java/org/example/pdnight/domain/user/controller/UserController.java
+++ b/src/main/java/org/example/pdnight/domain/user/controller/UserController.java
@@ -1,12 +1,12 @@
 package org.example.pdnight.domain.user.controller;
 
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.pdnight.domain.common.dto.ApiResponse;
 import org.example.pdnight.domain.common.dto.PagedResponse;
-import org.example.pdnight.domain.participant.enums.JoinStatus;
-import org.example.pdnight.domain.post.dto.response.PostResponseDto;
+import org.example.pdnight.domain.common.enums.JoinStatus;
+import org.example.pdnight.domain.invite.dto.response.InviteResponseDto;
+import org.example.pdnight.domain.invite.service.InviteService;
 import org.example.pdnight.domain.post.dto.response.PostResponseWithApplyStatusDto;
 import org.example.pdnight.domain.post.service.PostService;
 import org.example.pdnight.domain.user.dto.response.PostWithJoinStatusAndAppliedAtResponseDto;
@@ -27,10 +27,12 @@ public class UserController {
 
     private final UserService userService;
     private final PostService postService;
+    private final InviteService inviteService;
 
 
+    // 내 좋아요 게시글 목록 조회
     @GetMapping("/my/likedPosts")
-    public ResponseEntity<ApiResponse<PagedResponse<PostResponseWithApplyStatusDto>>> getMyLikedPosts(
+    public ResponseEntity<ApiResponse<?>> getMyLikedPosts(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PageableDefault(size = 10,page = 0) Pageable pageable
     ){
@@ -39,8 +41,9 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.ok("내 좋아요 게시글 목록이 조회되었습니다.",myLikedPost));
     }
 
+    //내 신청/성사된 게시글 조회
     @GetMapping("/my/confirmedPosts")
-    public ResponseEntity<ApiResponse<PagedResponse<PostWithJoinStatusAndAppliedAtResponseDto>>> getMyConfirmedPosts(
+    public ResponseEntity<ApiResponse<?>> getMyConfirmedPosts(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam (required = false) JoinStatus joinStatus,
             @PageableDefault(size = 10,page = 0) Pageable pageable
@@ -50,8 +53,10 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.ok("참여 신청한 게시글 목록이 조회되었습니다.",myLikedPost));
     }
 
+
+    // 내가 작성한 게시글 조회
     @GetMapping("/my/writtenPosts")
-    public ResponseEntity<ApiResponse<PagedResponse<PostResponseWithApplyStatusDto>>> getMyWrittenPosts(
+    public ResponseEntity<ApiResponse<?>> getMyWrittenPosts(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PageableDefault(size = 10,page = 0) Pageable pageable
     ){
@@ -60,6 +65,8 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.ok("내가 작성 한 게시물이 조회되었습니다.",myLikedPost));
     }
 
+
+    // 본인 프로필 조회
     @GetMapping("/my")
     public ResponseEntity<ApiResponse<?>> getMyProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -72,6 +79,7 @@ public class UserController {
         ));
     }
 
+    // 본인 프로필 수정
     @PatchMapping("/my/profile")
     public ResponseEntity<ApiResponse<?>> updateMyProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -85,6 +93,7 @@ public class UserController {
         ));
     }
 
+    // 비밀번호 변경
     @PatchMapping("/my/password")
     public ResponseEntity<ApiResponse<?>> updatePassword(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -99,6 +108,8 @@ public class UserController {
         ));
     }
 
+
+    // 유저 프로필 조회
     @GetMapping("/{id}/profile")
     public ResponseEntity<ApiResponse<?>> getProfile(
             @PathVariable Long id
@@ -109,6 +120,8 @@ public class UserController {
         ));
     }
 
+
+    //평가 조회
     @GetMapping("/{id}/evaluation")
     public ResponseEntity<ApiResponse<?>> getEvaluation(
             @PathVariable Long id
@@ -119,5 +132,18 @@ public class UserController {
         ));
     }
 
+    // -------------------- 내 초대 API -----------------------------------------//
+    //내 초대받은 목록 조회
+    @GetMapping("/my/invited")
+    public ResponseEntity<ApiResponse<?>> getMyInvited(
+            @AuthenticationPrincipal CustomUserDetails loggedInUser
+    ){
+        Long userId = loggedInUser.getUserId();
+        PagedResponse<InviteResponseDto> inviteResponseDto = inviteService.getMyInvited(userId);
+
+        return ResponseEntity.ok(ApiResponse.ok("초대 받은 목록 조회가 완료되었습니다",inviteResponseDto));
+    }
+
+    //내가 보낸 초대 목록 조회
 
 }

--- a/src/main/java/org/example/pdnight/domain/user/controller/UserController.java
+++ b/src/main/java/org/example/pdnight/domain/user/controller/UserController.java
@@ -13,6 +13,7 @@ import org.example.pdnight.domain.user.dto.response.PostWithJoinStatusAndApplied
 import org.example.pdnight.domain.user.service.UserService;
 import org.example.pdnight.global.filter.CustomUserDetails;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.example.pdnight.domain.user.dto.request.UserPasswordUpdateRequest;
@@ -136,14 +137,27 @@ public class UserController {
     //내 초대받은 목록 조회
     @GetMapping("/my/invited")
     public ResponseEntity<ApiResponse<?>> getMyInvited(
-            @AuthenticationPrincipal CustomUserDetails loggedInUser
+            @AuthenticationPrincipal CustomUserDetails loggedInUser,
+            @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
     ){
         Long userId = loggedInUser.getUserId();
-        PagedResponse<InviteResponseDto> inviteResponseDto = inviteService.getMyInvited(userId);
+        PagedResponse<InviteResponseDto> inviteResponseDto = inviteService.getMyInvited(userId,pageable);
 
         return ResponseEntity.ok(ApiResponse.ok("초대 받은 목록 조회가 완료되었습니다",inviteResponseDto));
     }
 
     //내가 보낸 초대 목록 조회
+    @GetMapping("/my/invite")
+    public ResponseEntity<ApiResponse<?>> getMyInvite(
+            @AuthenticationPrincipal CustomUserDetails loggedInUser,
+            @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ){
+        Long userId = loggedInUser.getUserId();
+        PagedResponse<InviteResponseDto> inviteResponseDto = inviteService.getMyInvite(userId,pageable);
+
+        return ResponseEntity.ok(ApiResponse.ok("초대 받은 목록 조회가 완료되었습니다",inviteResponseDto));
+    }
 
 }

--- a/src/main/java/org/example/pdnight/domain/user/controller/UserController.java
+++ b/src/main/java/org/example/pdnight/domain/user/controller/UserController.java
@@ -7,6 +7,7 @@ import org.example.pdnight.domain.common.dto.ApiResponse;
 import org.example.pdnight.domain.common.dto.PagedResponse;
 import org.example.pdnight.domain.participant.enums.JoinStatus;
 import org.example.pdnight.domain.post.dto.response.PostResponseDto;
+import org.example.pdnight.domain.post.dto.response.PostResponseWithApplyStatusDto;
 import org.example.pdnight.domain.post.service.PostService;
 import org.example.pdnight.domain.user.dto.response.PostWithJoinStatusAndAppliedAtResponseDto;
 import org.example.pdnight.domain.user.service.UserService;
@@ -29,12 +30,12 @@ public class UserController {
 
 
     @GetMapping("/my/likedPosts")
-    public ResponseEntity<ApiResponse<PagedResponse<PostResponseDto>>> getMyLikedPosts(
+    public ResponseEntity<ApiResponse<PagedResponse<PostResponseWithApplyStatusDto>>> getMyLikedPosts(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PageableDefault(size = 10,page = 0) Pageable pageable
     ){
         Long id = userDetails.getUserId();
-        PagedResponse<PostResponseDto> myLikedPost = postService.findMyLikedPosts(id, pageable);
+        PagedResponse<PostResponseWithApplyStatusDto> myLikedPost = postService.findMyLikedPosts(id, pageable);
         return ResponseEntity.ok(ApiResponse.ok("내 좋아요 게시글 목록이 조회되었습니다.",myLikedPost));
     }
 
@@ -50,12 +51,12 @@ public class UserController {
     }
 
     @GetMapping("/my/writtenPosts")
-    public ResponseEntity<ApiResponse<PagedResponse<PostResponseDto>>> getMyWrittenPosts(
+    public ResponseEntity<ApiResponse<PagedResponse<PostResponseWithApplyStatusDto>>> getMyWrittenPosts(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PageableDefault(size = 10,page = 0) Pageable pageable
     ){
         Long id = userDetails.getUserId();
-        PagedResponse<PostResponseDto> myLikedPost = postService.findMyWrittenPosts(id, pageable);
+        PagedResponse<PostResponseWithApplyStatusDto> myLikedPost = postService.findMyWrittenPosts(id, pageable);
         return ResponseEntity.ok(ApiResponse.ok("내가 작성 한 게시물이 조회되었습니다.",myLikedPost));
     }
 
@@ -117,4 +118,6 @@ public class UserController {
                 userService.getEvaluation(id)
         ));
     }
+
+
 }

--- a/src/main/java/org/example/pdnight/domain/user/controller/UserController.java
+++ b/src/main/java/org/example/pdnight/domain/user/controller/UserController.java
@@ -121,6 +121,19 @@ public class UserController {
         ));
     }
 
+    //유저 검색
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<?>> searchUsers(
+            @RequestParam String search,
+            @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ){
+        return ResponseEntity.ok(ApiResponse.ok(
+                "유저 검색이 완료 되었습니다.",
+                userService.searchUsers(search,pageable)
+        ));
+    }
+
 
     //평가 조회
     @GetMapping("/{id}/evaluation")

--- a/src/main/java/org/example/pdnight/domain/user/dto/request/ConfirmedPostRequestDto.java
+++ b/src/main/java/org/example/pdnight/domain/user/dto/request/ConfirmedPostRequestDto.java
@@ -2,7 +2,7 @@ package org.example.pdnight.domain.user.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
-import org.example.pdnight.domain.participant.enums.JoinStatus;
+import org.example.pdnight.domain.common.enums.JoinStatus;
 
 @Getter
 public class ConfirmedPostRequestDto {

--- a/src/main/java/org/example/pdnight/domain/user/dto/response/PostWithJoinStatusAndAppliedAtResponseDto.java
+++ b/src/main/java/org/example/pdnight/domain/user/dto/response/PostWithJoinStatusAndAppliedAtResponseDto.java
@@ -3,11 +3,10 @@ package org.example.pdnight.domain.user.dto.response;
 import java.time.LocalDateTime;
 
 import com.querydsl.core.annotations.QueryProjection;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.pdnight.domain.common.enums.JobCategory;
-import org.example.pdnight.domain.participant.enums.JoinStatus;
+import org.example.pdnight.domain.common.enums.JoinStatus;
 import org.example.pdnight.domain.post.enums.AgeLimit;
 import org.example.pdnight.domain.post.enums.Gender;
 import org.example.pdnight.domain.post.enums.PostStatus;

--- a/src/main/java/org/example/pdnight/domain/user/entity/User.java
+++ b/src/main/java/org/example/pdnight/domain/user/entity/User.java
@@ -1,6 +1,8 @@
 package org.example.pdnight.domain.user.entity;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -10,6 +12,7 @@ import org.example.pdnight.domain.auth.dto.request.SignupRequestDto;
 import org.example.pdnight.domain.common.entity.Timestamped;
 import org.example.pdnight.domain.common.enums.UserRole;
 import org.example.pdnight.domain.hobby.entity.Hobby;
+import org.example.pdnight.domain.invite.entity.Invite;
 import org.example.pdnight.domain.post.enums.Gender;
 import org.example.pdnight.domain.common.enums.JobCategory;
 import org.example.pdnight.domain.techStack.entity.TechStack;
@@ -67,6 +70,14 @@ public class User extends Timestamped {
 
     private Long totalRate;
     private Long totalReviewer;
+
+    //유저 삭제 하면 초대 알아서 삭제 되도록
+    @OneToMany(mappedBy = "inviter", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Invite> sentInvites = new ArrayList<>();
+
+    //유저 삭제 하면 초대 알아서 삭제 되도록
+    @OneToMany(mappedBy = "invitee", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Invite> receivedInvites = new ArrayList<>();
 
     private Boolean isDeleted = false;
     private LocalDateTime deletedAt;

--- a/src/main/java/org/example/pdnight/domain/user/repository/UserRepositoryQuery.java
+++ b/src/main/java/org/example/pdnight/domain/user/repository/UserRepositoryQuery.java
@@ -1,0 +1,9 @@
+package org.example.pdnight.domain.user.repository;
+
+import org.example.pdnight.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface UserRepositoryQuery {
+    Page<User> searchUsers(String search, Pageable pageable);
+}

--- a/src/main/java/org/example/pdnight/domain/user/repository/UserRepositoryQueryImpl.java
+++ b/src/main/java/org/example/pdnight/domain/user/repository/UserRepositoryQueryImpl.java
@@ -1,0 +1,47 @@
+package org.example.pdnight.domain.user.repository;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.user.entity.QUser;
+import org.example.pdnight.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryQueryImpl implements  UserRepositoryQuery{
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<User> searchUsers(String search, Pageable pageable) {
+        QUser user = QUser.user;
+
+        List<User> content = queryFactory
+                .selectFrom(user)
+                .where(
+                        user.name.containsIgnoreCase(search)
+                                .or(user.nickname.containsIgnoreCase(search)
+                                        .or(user.email.containsIgnoreCase(search)))
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // Count 쿼리
+        JPAQuery<Long> countQuery = queryFactory
+                .select(user.count())
+                .from(user)
+                .where(
+                        user.name.containsIgnoreCase(search)
+                                .or(user.nickname.containsIgnoreCase(search))
+                );
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+}

--- a/src/main/java/org/example/pdnight/domain/user/service/UserService.java
+++ b/src/main/java/org/example/pdnight/domain/user/service/UserService.java
@@ -2,18 +2,10 @@ package org.example.pdnight.domain.user.service;
 
 
 import lombok.RequiredArgsConstructor;
-import org.example.pdnight.domain.common.dto.PagedResponse;
 import org.example.pdnight.domain.hobby.entity.Hobby;
 import org.example.pdnight.domain.hobby.repository.HobbyRepository;
-import org.example.pdnight.domain.participant.enums.JoinStatus;
-import org.example.pdnight.domain.post.dto.response.PostResponseDto;
-import org.example.pdnight.domain.post.entity.Post;
 import org.example.pdnight.domain.techStack.entity.TechStack;
 import org.example.pdnight.domain.techStack.repository.TechStackRepository;
-import org.example.pdnight.domain.post.repository.PostRepositoryQueryImpl;
-import org.example.pdnight.domain.user.dto.response.PostWithJoinStatusAndAppliedAtResponseDto;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import at.favre.lib.crypto.bcrypt.BCrypt;
 import org.example.pdnight.domain.common.enums.ErrorCode;
 import org.example.pdnight.domain.common.exception.BaseException;
@@ -105,5 +97,10 @@ public class UserService {
                 ()-> new BaseException(ErrorCode.USER_NOT_FOUND));
 
         return new UserEvaluationResponse(user);
+    }
+
+    public User getUserById(Long id){
+        return userRepository.findById(id).orElseThrow(
+                ()-> new BaseException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/org/example/pdnight/domain/user/service/UserService.java
+++ b/src/main/java/org/example/pdnight/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package org.example.pdnight.domain.user.service;
 
 
 import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.common.dto.PagedResponse;
 import org.example.pdnight.domain.hobby.entity.Hobby;
 import org.example.pdnight.domain.hobby.repository.HobbyRepository;
 import org.example.pdnight.domain.techStack.entity.TechStack;
@@ -15,6 +16,9 @@ import org.example.pdnight.domain.user.dto.response.UserEvaluationResponse;
 import org.example.pdnight.domain.user.dto.response.UserResponseDto;
 import org.example.pdnight.domain.user.entity.User;
 import org.example.pdnight.domain.user.repository.UserRepository;
+import org.example.pdnight.domain.user.repository.UserRepositoryQuery;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +29,7 @@ public class UserService {
     private final HobbyRepository hobbyRepository;
     private final TechStackRepository techStackRepository;
     private final UserRepository userRepository;
+    private final UserRepositoryQuery userRepositoryQuery;
 
     public UserResponseDto getMyProfile(Long userId){
         // id로 유저 조회
@@ -102,5 +107,12 @@ public class UserService {
     public User getUserById(Long id){
         return userRepository.findById(id).orElseThrow(
                 ()-> new BaseException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    //유저 이름이나 닉네임이나 이메일로 검색
+    public PagedResponse<UserResponseDto> searchUsers(String search, Pageable pageable) {
+        Page<User> users = userRepositoryQuery.searchUsers(search,pageable);
+        Page<UserResponseDto> dtos = users.map(UserResponseDto::new);
+        return PagedResponse.from(dtos);
     }
 }

--- a/src/main/java/org/example/pdnight/global/config/SecurityConfig.java
+++ b/src/main/java/org/example/pdnight/global/config/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/signup").permitAll()
                         .requestMatchers("/api/auth/login").permitAll()
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .build();

--- a/src/test/java/org/example/pdnight/domain/participant/service/BaseParticipantTest.java
+++ b/src/test/java/org/example/pdnight/domain/participant/service/BaseParticipantTest.java
@@ -1,7 +1,7 @@
 package org.example.pdnight.domain.participant.service;
 
 import org.example.pdnight.domain.participant.entity.PostParticipant;
-import org.example.pdnight.domain.participant.enums.JoinStatus;
+import org.example.pdnight.domain.common.enums.JoinStatus;
 import org.example.pdnight.domain.post.entity.Post;
 import org.example.pdnight.domain.post.enums.PostStatus;
 import org.example.pdnight.domain.post.repository.PostRepository;

--- a/src/test/java/org/example/pdnight/domain/participant/service/ParticipantServiceExceptionTest.java
+++ b/src/test/java/org/example/pdnight/domain/participant/service/ParticipantServiceExceptionTest.java
@@ -44,7 +44,7 @@ public class ParticipantServiceExceptionTest extends BaseParticipantTest {
         );
 
         //then
-        assertEquals(ErrorCode.CANNOT_PARTICIPANT_SELF.getMessage(), exception.getMessage());
+        assertEquals(ErrorCode.CANNOT_PARTICIPATE_SELF.getMessage(), exception.getMessage());
     }
 
     @Test
@@ -179,7 +179,7 @@ public class ParticipantServiceExceptionTest extends BaseParticipantTest {
         );
 
         //then
-        assertEquals(ErrorCode.NOT_PARTICIPANT.getMessage(), exception.getMessage());
+        assertEquals(ErrorCode.NOT_PARTICIPATED.getMessage(), exception.getMessage());
     }
 
     @Test

--- a/src/test/java/org/example/pdnight/domain/participant/service/ParticipantServiceExceptionTest.java
+++ b/src/test/java/org/example/pdnight/domain/participant/service/ParticipantServiceExceptionTest.java
@@ -3,7 +3,7 @@ package org.example.pdnight.domain.participant.service;
 import org.example.pdnight.domain.common.enums.ErrorCode;
 import org.example.pdnight.domain.common.exception.BaseException;
 import org.example.pdnight.domain.participant.entity.PostParticipant;
-import org.example.pdnight.domain.participant.enums.JoinStatus;
+import org.example.pdnight.domain.common.enums.JoinStatus;
 import org.example.pdnight.domain.participant.repository.ParticipantRepository;
 import org.example.pdnight.domain.post.entity.Post;
 import org.example.pdnight.domain.user.entity.User;

--- a/src/test/java/org/example/pdnight/domain/participant/service/ParticipantServiceSuccessTest.java
+++ b/src/test/java/org/example/pdnight/domain/participant/service/ParticipantServiceSuccessTest.java
@@ -3,7 +3,7 @@ package org.example.pdnight.domain.participant.service;
 import org.example.pdnight.domain.common.dto.PagedResponse;
 import org.example.pdnight.domain.participant.dto.response.ParticipantResponse;
 import org.example.pdnight.domain.participant.entity.PostParticipant;
-import org.example.pdnight.domain.participant.enums.JoinStatus;
+import org.example.pdnight.domain.common.enums.JoinStatus;
 import org.example.pdnight.domain.participant.repository.ParticipantRepository;
 import org.example.pdnight.domain.post.entity.Post;
 import org.example.pdnight.domain.user.entity.User;

--- a/src/test/java/org/example/pdnight/domain/post/service/PostServiceTest.java
+++ b/src/test/java/org/example/pdnight/domain/post/service/PostServiceTest.java
@@ -13,11 +13,13 @@ import org.example.pdnight.domain.common.exception.BaseException;
 import org.example.pdnight.domain.post.dto.request.PostRequestDto;
 import org.example.pdnight.domain.post.dto.request.PostUpdateRequestDto;
 import org.example.pdnight.domain.post.dto.response.PostResponseDto;
+import org.example.pdnight.domain.post.dto.response.PostResponseWithApplyStatusDto;
 import org.example.pdnight.domain.post.entity.Post;
 import org.example.pdnight.domain.post.enums.AgeLimit;
 import org.example.pdnight.domain.post.enums.Gender;
 import org.example.pdnight.domain.post.enums.PostStatus;
 import org.example.pdnight.domain.post.repository.PostRepository;
+import org.example.pdnight.domain.post.repository.PostRepositoryQuery;
 import org.example.pdnight.domain.user.entity.User;
 import org.example.pdnight.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +39,10 @@ import org.springframework.data.domain.Pageable;
 class PostServiceTest {
 	@Mock
 	private PostRepository postRepository;
+
+
+	@Mock
+	private PostRepositoryQuery postRepositoryQuery;
 
 	@Mock
 	private UserRepository userRepository;
@@ -103,7 +109,7 @@ class PostServiceTest {
 
 		//when
 		when(postRepository.findByIdAndStatus(postId, PostStatus.OPEN)).thenReturn(Optional.of(post));
-		PostResponseDto responseDto = postService.findOpenedPost(postId);
+		PostResponseWithApplyStatusDto responseDto = postService.findOpenedPost(postId);
 
 		//then
 		assertNotNull(responseDto);
@@ -210,11 +216,11 @@ class PostServiceTest {
 		JobCategory jobCategoryLimit = JobCategory.BACK_END_DEVELOPER;
 		Gender genderLimit = Gender.MALE;
 
-		PostResponseDto mockDto = new PostResponseDto(post);
+		PostResponseWithApplyStatusDto mockDto = new PostResponseWithApplyStatusDto();
 
-		Page<PostResponseDto> page = new PageImpl<>(List.of(mockDto), pageable, 1);
+		Page<PostResponseWithApplyStatusDto> page = new PageImpl<>(List.of(mockDto), pageable, 1);
 
-		when(postRepository.findPostDtosBySearch(
+		when(postRepositoryQuery.findPostDtosBySearch(
 			pageable,
 			maxParticipants,
 			ageLimit,
@@ -223,7 +229,7 @@ class PostServiceTest {
 		).thenReturn(page);
 
 		//when
-		Page<PostResponseDto> responseDtos = postService.getPostDtosBySearch(pageable, maxParticipants, ageLimit,
+		Page<PostResponseWithApplyStatusDto> responseDtos = postService.getPostDtosBySearch(pageable, maxParticipants, ageLimit,
 			jobCategoryLimit, genderLimit);
 
 		//then
@@ -241,9 +247,9 @@ class PostServiceTest {
 		JobCategory jobCategoryLimit = JobCategory.BACK_END_DEVELOPER;
 		Gender genderLimit = Gender.MALE;
 
-		Page<PostResponseDto> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+		Page<PostResponseWithApplyStatusDto> emptyPage = new PageImpl<>(List.of(), pageable, 0);
 
-		when(postRepository.findPostDtosBySearch(
+		when(postRepositoryQuery.findPostDtosBySearch(
 			pageable,
 			maxParticipants,
 			ageLimit,
@@ -252,7 +258,7 @@ class PostServiceTest {
 		).thenReturn(emptyPage);
 
 		//when
-		Page<PostResponseDto> responseDtos = postService.getPostDtosBySearch(pageable, maxParticipants, ageLimit,
+		Page<PostResponseWithApplyStatusDto> responseDtos = postService.getPostDtosBySearch(pageable, maxParticipants, ageLimit,
 			jobCategoryLimit, genderLimit);
 
 		//then

--- a/src/test/java/org/example/pdnight/domain/user/service/UserMyPostListServiceTest.java
+++ b/src/test/java/org/example/pdnight/domain/user/service/UserMyPostListServiceTest.java
@@ -2,19 +2,13 @@ package org.example.pdnight.domain.user.service;
 
 import org.example.pdnight.domain.common.dto.PagedResponse;
 import org.example.pdnight.domain.common.enums.JobCategory;
-import org.example.pdnight.domain.participant.entity.PostParticipant;
-import org.example.pdnight.domain.participant.enums.JoinStatus;
-import org.example.pdnight.domain.post.dto.request.PostRequestDto;
-import org.example.pdnight.domain.post.dto.response.PostResponseDto;
+import org.example.pdnight.domain.common.enums.JoinStatus;
 import org.example.pdnight.domain.post.dto.response.PostResponseWithApplyStatusDto;
-import org.example.pdnight.domain.post.entity.Post;
 import org.example.pdnight.domain.post.enums.AgeLimit;
 import org.example.pdnight.domain.post.enums.Gender;
 import org.example.pdnight.domain.post.enums.PostStatus;
-import org.example.pdnight.domain.post.repository.PostRepositoryQuery;
 import org.example.pdnight.domain.post.repository.PostRepositoryQueryImpl;
 import org.example.pdnight.domain.post.service.PostService;
-import org.example.pdnight.domain.user.entity.User;
 
 import org.example.pdnight.domain.user.dto.response.PostWithJoinStatusAndAppliedAtResponseDto;
 

--- a/src/test/java/org/example/pdnight/domain/user/service/UserMyPostListServiceTest.java
+++ b/src/test/java/org/example/pdnight/domain/user/service/UserMyPostListServiceTest.java
@@ -6,9 +6,11 @@ import org.example.pdnight.domain.participant.entity.PostParticipant;
 import org.example.pdnight.domain.participant.enums.JoinStatus;
 import org.example.pdnight.domain.post.dto.request.PostRequestDto;
 import org.example.pdnight.domain.post.dto.response.PostResponseDto;
+import org.example.pdnight.domain.post.dto.response.PostResponseWithApplyStatusDto;
 import org.example.pdnight.domain.post.entity.Post;
 import org.example.pdnight.domain.post.enums.AgeLimit;
 import org.example.pdnight.domain.post.enums.Gender;
+import org.example.pdnight.domain.post.enums.PostStatus;
 import org.example.pdnight.domain.post.repository.PostRepositoryQuery;
 import org.example.pdnight.domain.post.repository.PostRepositoryQueryImpl;
 import org.example.pdnight.domain.post.service.PostService;
@@ -47,24 +49,55 @@ class PostServiceTest {
         Long userId = 1L;
         Pageable pageable = PageRequest.of(0, 10);
 
-        User author = mock(User.class);  // 또는 직접 생성해도 됨
-        Post post1 = Post.createPost(author, "제목1", LocalDateTime.now(), "공개", "비공개", 4,
-                Gender.MALE, JobCategory.BACK_END_DEVELOPER, AgeLimit.AGE_20S);
-        Post post2 = Post.createPost(author, "제목2", LocalDateTime.now(), "공개", "비공개", 4,
-                Gender.MALE, JobCategory.BACK_END_DEVELOPER, AgeLimit.AGE_20S);
+        PostResponseWithApplyStatusDto post1 = new PostResponseWithApplyStatusDto(
+                1L,
+                2L,
+                "제목1",
+                LocalDateTime.now(),
+                "공개내용1",
+                "비공개내용1",
+                PostStatus.OPEN,
+                4,
+                Gender.MALE,
+                JobCategory.BACK_END_DEVELOPER,
+                AgeLimit.AGE_20S,
+                2L, // 신청자 수
+                1L, // 확정자 수
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
 
-        List<Post> postList = List.of(post1, post2);
-        Page<Post> postPage = new PageImpl<>(postList);
+        PostResponseWithApplyStatusDto post2 = new PostResponseWithApplyStatusDto(
+                2L,
+                2L,
+                "제목2",
+                LocalDateTime.now(),
+                "공개내용2",
+                "비공개내용2",
+                PostStatus.OPEN,
+                4,
+                Gender.MALE,
+                JobCategory.BACK_END_DEVELOPER,
+                AgeLimit.AGE_20S,
+                3L,
+                2L,
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+
+        List<PostResponseWithApplyStatusDto> postList = List.of(post1, post2);
+        Page<PostResponseWithApplyStatusDto> postPage = new PageImpl<>(postList);
 
         when(postRepositoryQuery.getMyLikePost(userId, pageable)).thenReturn(postPage);
 
         // when
-        PagedResponse<PostResponseDto> response = postService.findMyLikedPosts(userId, pageable);
+        PagedResponse<PostResponseWithApplyStatusDto> response = postService.findMyLikedPosts(userId, pageable);
 
         // then
         assertThat(response.contents()).hasSize(2);
         verify(postRepositoryQuery).getMyLikePost(userId, pageable);
     }
+
 
 
     @Test
@@ -95,13 +128,13 @@ class PostServiceTest {
         Long userId = 1L;
         Pageable pageable = PageRequest.of(0, 10);
 
-        List<PostResponseDto> dtoList = List.of(new PostResponseDto(), new PostResponseDto());
-        Page<PostResponseDto> page = new PageImpl<>(dtoList);
+        List<PostResponseWithApplyStatusDto> dtoList = List.of(new PostResponseWithApplyStatusDto(), new PostResponseWithApplyStatusDto());
+        Page<PostResponseWithApplyStatusDto> page = new PageImpl<>(dtoList);
 
         when(postRepositoryQuery.getWrittenPost(userId, pageable)).thenReturn(page);
 
         // when
-        PagedResponse<PostResponseDto> response = postService.findMyWrittenPosts(userId, pageable);
+        PagedResponse<PostResponseWithApplyStatusDto> response = postService.findMyWrittenPosts(userId, pageable);
 
         // then
         assertThat(response.contents()).hasSize(2);


### PR DESCRIPTION
## PDNight 커밋 히스토리 요약 (최근 9시간)
### 기능 추가 (Feature)
- [feat(AdminPost) : 어드민 Post 삭제 API 구현]
→ 관리자 권한으로 게시글을 삭제할 수 있는 기능 구현

### [feat(PostParticipate): 게시글 참여 신청 (제한 로직 추가)]
→ 게시글 참여 시 연령/성별/직군 조건 제한 로직 추가

### [feat & refactoring(Post) : 추천 게시글 조회 API 구현 및 게시글 목록 조회 개선]
→ 추천 게시글 조회 API 구현
→ 게시글 목록에 참여 신청자 수, 확정된 인원 수 포함하도록 개선

## 리팩토링 (Refactor)
### [refactoring(participate) : 선착순 로직 리팩토링 (동시성 제어는 미구현)]
→ 선착순 로직을 간결하고 명확하게 리팩토링
→ 아직 동시성 제어는 미적용 상태

## 버그 수정 / 개선 (Fix)
### [fix(ErrorCode) : 게시물 신청 에러코드 추가]
→ 참여 불가 상황을 명확히 하기 위해 관련 에러 코드 추가