### PR TITLE
Feat/comment

### DIFF
--- a/src/main/java/org/example/pdnight/domain/comment/controller/CommentController.java
+++ b/src/main/java/org/example/pdnight/domain/comment/controller/CommentController.java
@@ -4,18 +4,22 @@ import org.example.pdnight.domain.comment.dto.request.CommentRequestDto;
 import org.example.pdnight.domain.comment.dto.response.CommentResponseDto;
 import org.example.pdnight.domain.comment.service.CommentService;
 import org.example.pdnight.domain.common.dto.ApiResponse;
+import org.example.pdnight.domain.common.dto.PagedResponse;
 import org.example.pdnight.global.filter.CustomUserDetails;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.Mapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
@@ -84,6 +88,20 @@ public class CommentController {
 
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(ApiResponse.ok("대댓글이 등록되었습니다.", response));
+	}
+
+	//댓글 다건조회 메서드
+	@GetMapping
+	public ResponseEntity<ApiResponse<PagedResponse<CommentResponseDto>>> getComments(
+		@PathVariable Long postId,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size
+	) {
+		Pageable pageable = PageRequest.of(page, size);
+		PagedResponse<CommentResponseDto> responses = commentService.getCommentsByPostId(postId, pageable);
+
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(ApiResponse.ok("댓글이 조회되었습니다.", responses));
 	}
 
 }

--- a/src/main/java/org/example/pdnight/domain/comment/controller/CommentController.java
+++ b/src/main/java/org/example/pdnight/domain/comment/controller/CommentController.java
@@ -1,0 +1,42 @@
+package org.example.pdnight.domain.comment.controller;
+
+import org.example.pdnight.domain.comment.dto.request.CommentRequestDto;
+import org.example.pdnight.domain.comment.dto.response.CommentResponseDto;
+import org.example.pdnight.domain.comment.service.CommentService;
+import org.example.pdnight.domain.common.dto.ApiResponse;
+import org.example.pdnight.global.filter.CustomUserDetails;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.Mapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/posts/{postId}/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+	private final CommentService commentService;
+
+	@PostMapping
+	public ResponseEntity<ApiResponse<CommentResponseDto>> saveComment(
+		@PathVariable Long postId,
+		@AuthenticationPrincipal CustomUserDetails loginUser,
+		@RequestBody CommentRequestDto request
+	) {
+		Long authorId = loginUser.getUserId();
+
+		CommentResponseDto response = commentService.createComment(postId, authorId, request);
+
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(ApiResponse.ok("댓글이 등록되었습니다.", response));
+	}
+
+}

--- a/src/main/java/org/example/pdnight/domain/comment/controller/CommentController.java
+++ b/src/main/java/org/example/pdnight/domain/comment/controller/CommentController.java
@@ -8,6 +8,7 @@ import org.example.pdnight.global.filter.CustomUserDetails;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.Mapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,6 +26,7 @@ public class CommentController {
 
 	private final CommentService commentService;
 
+	//댓글 생성 메서드
 	@PostMapping
 	public ResponseEntity<ApiResponse<CommentResponseDto>> saveComment(
 		@PathVariable Long postId,
@@ -32,11 +34,25 @@ public class CommentController {
 		@RequestBody CommentRequestDto request
 	) {
 		Long authorId = loginUser.getUserId();
-
 		CommentResponseDto response = commentService.createComment(postId, authorId, request);
 
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(ApiResponse.ok("댓글이 등록되었습니다.", response));
 	}
+
+	//댓글 삭제 메서드
+	@DeleteMapping("/{id}")
+	public ResponseEntity<ApiResponse<Void>> deleteComment(
+		@PathVariable Long postId,
+		@PathVariable Long id,
+		@AuthenticationPrincipal CustomUserDetails loginUser
+	){
+		Long authorId = loginUser.getUserId();
+		commentService.deleteCommentById(postId, authorId, id);
+
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(ApiResponse.ok("댓글이 삭제되었습니다.", null));
+	}
+
 
 }

--- a/src/main/java/org/example/pdnight/domain/comment/controller/CommentController.java
+++ b/src/main/java/org/example/pdnight/domain/comment/controller/CommentController.java
@@ -71,4 +71,19 @@ public class CommentController {
 			.body(ApiResponse.ok("댓글이 수정되었습니다.", response));
 	}
 
+	//대댓글 생성 메서드
+	@PostMapping("/{id}/comments")
+	public ResponseEntity<ApiResponse<CommentResponseDto>> saveChildComment(
+		@PathVariable Long postId,
+		@PathVariable Long id,
+		@AuthenticationPrincipal CustomUserDetails loginUser,
+		@Valid @RequestBody CommentRequestDto request
+	) {
+		Long authorId = loginUser.getUserId();
+		CommentResponseDto response = commentService.createChildComment(postId, id, authorId, request);
+
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(ApiResponse.ok("대댓글이 등록되었습니다.", response));
+	}
+
 }

--- a/src/main/java/org/example/pdnight/domain/comment/controller/CommentController.java
+++ b/src/main/java/org/example/pdnight/domain/comment/controller/CommentController.java
@@ -11,12 +11,14 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.Mapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -48,11 +50,25 @@ public class CommentController {
 		@AuthenticationPrincipal CustomUserDetails loginUser
 	){
 		Long authorId = loginUser.getUserId();
-		commentService.deleteCommentById(postId, authorId, id);
+		commentService.deleteCommentById(postId, id, authorId);
 
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(ApiResponse.ok("댓글이 삭제되었습니다.", null));
 	}
 
+	//댓글 수정 메서드
+	@PatchMapping("/{id}")
+	public ResponseEntity<ApiResponse<CommentResponseDto>> updateComment(
+		@PathVariable Long postId,
+		@PathVariable Long id,
+		@AuthenticationPrincipal CustomUserDetails loginUser,
+		@Valid @RequestBody CommentRequestDto request
+	){
+		Long authorId = loginUser.getUserId();
+		CommentResponseDto response = commentService.updateCommentByDto(postId, id, authorId, request);
+
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(ApiResponse.ok("댓글이 수정되었습니다.", response));
+	}
 
 }

--- a/src/main/java/org/example/pdnight/domain/comment/dto/request/CommentRequestDto.java
+++ b/src/main/java/org/example/pdnight/domain/comment/dto/request/CommentRequestDto.java
@@ -1,0 +1,10 @@
+package org.example.pdnight.domain.comment.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class CommentRequestDto {
+
+	private String content;
+
+}

--- a/src/main/java/org/example/pdnight/domain/comment/dto/request/CommentRequestDto.java
+++ b/src/main/java/org/example/pdnight/domain/comment/dto/request/CommentRequestDto.java
@@ -1,9 +1,13 @@
 package org.example.pdnight.domain.comment.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class CommentRequestDto {
 
 	@NotBlank(message = "변경내용은 필수값입니다.")

--- a/src/main/java/org/example/pdnight/domain/comment/dto/request/CommentRequestDto.java
+++ b/src/main/java/org/example/pdnight/domain/comment/dto/request/CommentRequestDto.java
@@ -1,10 +1,12 @@
 package org.example.pdnight.domain.comment.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class CommentRequestDto {
 
+	@NotBlank(message = "변경내용은 필수값입니다.")
 	private String content;
 
 }

--- a/src/main/java/org/example/pdnight/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/org/example/pdnight/domain/comment/dto/response/CommentResponseDto.java
@@ -16,11 +16,12 @@ public class CommentResponseDto {
 	private final Long postId;
 	private final Long authorId;
 	private final String content;
-	private final LocalDateTime createdAt;
-	private final LocalDateTime updatedAt;
 
 	//대댓글일 경우에만 기입
 	private final Long parentId;
+
+	private final LocalDateTime createdAt;
+	private final LocalDateTime updatedAt;
 
 	private CommentResponseDto(Comment comment) {
 		this.id = comment.getId();

--- a/src/main/java/org/example/pdnight/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/org/example/pdnight/domain/comment/dto/response/CommentResponseDto.java
@@ -1,0 +1,39 @@
+package org.example.pdnight.domain.comment.dto.response;
+
+import java.time.LocalDateTime;
+
+import org.example.pdnight.domain.comment.entity.Comment;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CommentResponseDto {
+
+	private final Long id;
+	private final Long postId;
+	private final Long authorId;
+	private final String content;
+	private final LocalDateTime createdAt;
+	private final LocalDateTime updatedAt;
+
+	//대댓글일 경우에만 기입
+	private final Long parentId;
+
+	private CommentResponseDto(Comment comment) {
+		this.id = comment.getId();
+		this.postId = comment.getPost().getId();
+		this.authorId = comment.getAuthor().getId();
+		this.content = comment.getContent();
+		this.createdAt = comment.getCreatedAt();
+		this.updatedAt = comment.getUpdatedAt();
+		this.parentId = comment.getParent() != null ? comment.getParent().getId() : null;
+	}
+
+	public static CommentResponseDto from(Comment comment) {
+		return new CommentResponseDto(comment);
+	}
+
+}

--- a/src/main/java/org/example/pdnight/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/org/example/pdnight/domain/comment/dto/response/CommentResponseDto.java
@@ -1,6 +1,8 @@
 package org.example.pdnight.domain.comment.dto.response;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.example.pdnight.domain.comment.entity.Comment;
 
@@ -23,6 +25,10 @@ public class CommentResponseDto {
 	private final LocalDateTime createdAt;
 	private final LocalDateTime updatedAt;
 
+	//리스트가 비어있으면 반환 안됨
+	@JsonInclude(JsonInclude.Include.NON_EMPTY)
+	private final List<CommentResponseDto> children = new ArrayList<>();
+
 	private CommentResponseDto(Comment comment) {
 		this.id = comment.getId();
 		this.postId = comment.getPost().getId();
@@ -35,6 +41,11 @@ public class CommentResponseDto {
 
 	public static CommentResponseDto from(Comment comment) {
 		return new CommentResponseDto(comment);
+	}
+
+	//댓글응답에 대댓글 추가 메서드
+	public void addChild(CommentResponseDto commentResponseDto) {
+		children.add(commentResponseDto);
 	}
 
 }

--- a/src/main/java/org/example/pdnight/domain/comment/entity/Comment.java
+++ b/src/main/java/org/example/pdnight/domain/comment/entity/Comment.java
@@ -85,4 +85,9 @@ public class Comment extends Timestamped {
 		return new Comment(post, author, content, parent);
 	}
 
+	//댓글 내용 수정 메서드
+	public void updateContent(String content) {
+		this.content = content;
+	}
+
 }

--- a/src/main/java/org/example/pdnight/domain/comment/entity/Comment.java
+++ b/src/main/java/org/example/pdnight/domain/comment/entity/Comment.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.example.pdnight.domain.common.entity.Timestamped;
+import org.example.pdnight.domain.common.enums.ErrorCode;
+import org.example.pdnight.domain.common.exception.BaseException;
 import org.example.pdnight.domain.post.entity.Post;
 import org.example.pdnight.domain.user.entity.User;
 
@@ -40,6 +42,9 @@ public class Comment extends Timestamped {
 
 	private String content;
 
+	//대댓글 트리 제한을 위한 필드 : 기본0, 부모가 있을 시 1
+	private int depth;
+
 	//부모댓글 - 자기참조
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "parent_id")
@@ -54,6 +59,7 @@ public class Comment extends Timestamped {
 		this.post = post;
 		this.author = author;
 		this.content = content;
+		this.depth = 0;
 	}
 
 	//대댓글 생성자
@@ -62,6 +68,7 @@ public class Comment extends Timestamped {
 		this.author = author;
 		this.content = content;
 		this.parent = parent;
+		this.depth = 1;
 	}
 
 	//댓글 생성 메서드
@@ -71,6 +78,10 @@ public class Comment extends Timestamped {
 
 	//대댓글 생성 메서드
 	public static Comment createChild(Post post, User author, String content, Comment parent) {
+		if (parent.depth >= 1) {
+			throw new BaseException(ErrorCode.INVALID_COMMENT_DEPTH);
+		}
+
 		return new Comment(post, author, content, parent);
 	}
 

--- a/src/main/java/org/example/pdnight/domain/comment/entity/Comment.java
+++ b/src/main/java/org/example/pdnight/domain/comment/entity/Comment.java
@@ -1,0 +1,77 @@
+package org.example.pdnight.domain.comment.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.example.pdnight.domain.common.entity.Timestamped;
+import org.example.pdnight.domain.post.entity.Post;
+import org.example.pdnight.domain.user.entity.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "comments")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends Timestamped {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "post_id")
+	private Post post;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "author_id")
+	private User author;
+
+	private String content;
+
+	//부모댓글 - 자기참조
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "parent_id")
+	private Comment parent;
+
+	//대댓글 리스트
+	@OneToMany(mappedBy = "parent")
+	private List<Comment> children = new ArrayList<>();
+
+	//댓글 생성자
+	private Comment(Post post, User author, String content) {
+		this.post = post;
+		this.author = author;
+		this.content = content;
+	}
+
+	//대댓글 생성자
+	private Comment(Post post, User author, String content, Comment parent) {
+		this.post = post;
+		this.author = author;
+		this.content = content;
+		this.parent = parent;
+	}
+
+	//댓글 생성 메서드
+	public static Comment create(Post post, User author, String content) {
+		return new Comment(post, author, content);
+	}
+
+	//대댓글 생성 메서드
+	public static Comment createChild(Post post, User author, String content, Comment parent) {
+		return new Comment(post, author, content, parent);
+	}
+
+}

--- a/src/main/java/org/example/pdnight/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/org/example/pdnight/domain/comment/repository/CommentRepository.java
@@ -1,7 +1,10 @@
 package org.example.pdnight.domain.comment.repository;
 
+import java.util.List;
+
 import org.example.pdnight.domain.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+	List<Comment> findByPostIdOrderByIdAsc(Long postId);
 }

--- a/src/main/java/org/example/pdnight/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/org/example/pdnight/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package org.example.pdnight.domain.comment.repository;
+
+import org.example.pdnight.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/org/example/pdnight/domain/comment/service/CommentService.java
+++ b/src/main/java/org/example/pdnight/domain/comment/service/CommentService.java
@@ -74,6 +74,21 @@ public class CommentService {
 		return CommentResponseDto.from(foundComment);
 	}
 
+	//대댓글 생성 메서드
+	public CommentResponseDto createChildComment(Long postId, Long id, Long authorId, CommentRequestDto request) {
+		//댓글을 기입될 게시글과, 작성자를 찾아옴 -> 없을 경우 예외 발생 -> 검증 로직
+		Post foundPost = getPostOrThrow(postRepository.findById(postId));
+		User foundUser = getUserOrThrow(userRepository.findByIdAndIsDeletedFalse(authorId));
+
+		Comment foundComment = getCommentOrThrow(commentRepository.findById(id));
+
+		//대댓글 엔티티 생성 및 저장
+		Comment childComment = Comment.createChild(foundPost, foundUser, request.getContent(), foundComment);
+		Comment savedChildComment = commentRepository.save(childComment);
+
+		return CommentResponseDto.from(savedChildComment);
+	}
+
 	//이하 헬퍼 메서드
 	private Comment getCommentOrThrow(Optional<Comment> comment) {
 		return comment.orElseThrow(() -> new BaseException(ErrorCode.COMMENT_NOT_FOUND));
@@ -97,6 +112,5 @@ public class CommentService {
 			throw new BaseException(ErrorCode.POST_NOT_MATCHED);
 		}
 	}
-
 
 }

--- a/src/main/java/org/example/pdnight/domain/comment/service/CommentService.java
+++ b/src/main/java/org/example/pdnight/domain/comment/service/CommentService.java
@@ -95,6 +95,7 @@ public class CommentService {
 	}
 
 	//댓글 다건 조회 메서드 : 해당게시글의 댓글리스트
+	@Transactional(readOnly = true)
 	public PagedResponse<CommentResponseDto> getCommentsByPostId(Long postId, Pageable pageable) {
 		//파람값으로 넘어온 게시글이 존재하는지 확인
 		Post foundPost = getPostOrThrow(postRepository.findById(postId));

--- a/src/main/java/org/example/pdnight/domain/comment/service/CommentService.java
+++ b/src/main/java/org/example/pdnight/domain/comment/service/CommentService.java
@@ -1,0 +1,58 @@
+package org.example.pdnight.domain.comment.service;
+
+import java.util.Optional;
+
+import org.example.pdnight.domain.comment.dto.request.CommentRequestDto;
+import org.example.pdnight.domain.comment.dto.response.CommentResponseDto;
+import org.example.pdnight.domain.comment.entity.Comment;
+import org.example.pdnight.domain.comment.repository.CommentRepository;
+import org.example.pdnight.domain.common.enums.ErrorCode;
+import org.example.pdnight.domain.common.exception.BaseException;
+import org.example.pdnight.domain.post.entity.Post;
+import org.example.pdnight.domain.post.repository.PostRepository;
+import org.example.pdnight.domain.user.entity.User;
+import org.example.pdnight.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+	private final CommentRepository commentRepository;
+	private final PostRepository postRepository;
+	private final UserRepository userRepository;
+
+	public CommentResponseDto createComment(Long postId, Long authorId, CommentRequestDto request) {
+		//댓글을 기입될 게시글과, 작성자를 찾아옴
+		Post foundPost = getPostOrThrow(postRepository.findById(postId));
+		User foundUser = getUserOrThrow(userRepository.findByIdAndIsDeletedFalse(authorId));
+
+		//댓글 엔티티 생성 및 저장
+		Comment comment = Comment.create(foundPost, foundUser, request.getContent());
+		Comment savedComment = commentRepository.save(comment);
+
+		return CommentResponseDto.from(savedComment);
+	}
+
+	//이하 헬퍼 메서드
+	private Comment getCommentOrThrow(Optional<Comment> comment) {
+		return comment.orElseThrow(() -> new BaseException(ErrorCode.COMMENT_NOT_FOUND));
+	}
+
+	private Post getPostOrThrow(Optional<Post> post) {
+		return post.orElseThrow(() -> new BaseException(ErrorCode.POST_NOT_FOUND));
+	}
+
+	private User getUserOrThrow(Optional<User> user) {
+		return user.orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
+	}
+
+	private void validateAuthor(Long userId, Post post) {
+		if (!post.getAuthor().getId().equals(userId)) {
+			throw new BaseException(ErrorCode.POST_FORBIDDEN);
+		}
+	}
+
+}

--- a/src/main/java/org/example/pdnight/domain/comment/service/CommentService.java
+++ b/src/main/java/org/example/pdnight/domain/comment/service/CommentService.java
@@ -13,11 +13,14 @@ import org.example.pdnight.domain.post.repository.PostRepository;
 import org.example.pdnight.domain.user.entity.User;
 import org.example.pdnight.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class CommentService {
 
 	private final CommentRepository commentRepository;
@@ -26,7 +29,7 @@ public class CommentService {
 
 	//댓글 생성 메서드
 	public CommentResponseDto createComment(Long postId, Long authorId, CommentRequestDto request) {
-		//댓글을 기입될 게시글과, 작성자를 찾아옴
+		//댓글을 기입될 게시글과, 작성자를 찾아옴 -> 없을 경우 예외 발생 -> 검증 로직
 		Post foundPost = getPostOrThrow(postRepository.findById(postId));
 		User foundUser = getUserOrThrow(userRepository.findByIdAndIsDeletedFalse(authorId));
 
@@ -38,15 +41,37 @@ public class CommentService {
 	}
 
 	//댓글 삭제 메서드
-	public void deleteCommentById(Long postId, Long authorId, Long id) {
+	@Transactional
+	public void deleteCommentById(Long postId, Long id, Long authorId) {
 		//댓글을 기입될 게시글과, 작성자를 찾아옴 -> 없을 경우 예외 발생 -> 검증 로직
 		Post foundPost = getPostOrThrow(postRepository.findById(postId));
 		User foundUser = getUserOrThrow(userRepository.findByIdAndIsDeletedFalse(authorId));
 
+		//댓글 검증 로직
 		Comment foundComment = getCommentOrThrow(commentRepository.findById(id));
 		validateAuthorAndPost(authorId, postId, foundComment);
 
 		commentRepository.delete(foundComment);
+	}
+
+	//댓글 수정 메서드
+	@Transactional
+	public CommentResponseDto updateCommentByDto(Long postId, Long id, Long authorId, CommentRequestDto request) {
+		//댓글을 기입될 게시글과, 작성자를 찾아옴 -> 없을 경우 예외 발생 -> 검증 로직
+		Post foundPost = getPostOrThrow(postRepository.findById(postId));
+		User foundUser = getUserOrThrow(userRepository.findByIdAndIsDeletedFalse(authorId));
+
+		//댓글 검증 로직
+		Comment foundComment = getCommentOrThrow(commentRepository.findById(id));
+		validateAuthorAndPost(authorId, postId, foundComment);
+
+		if(foundComment.getContent().equals(request.getContent())) {
+			log.info("요청과 기존 댓글 내용이 동일하여 업데이트를 생략합니다. commentId = {}", foundComment.getId());
+			return CommentResponseDto.from(foundComment);
+		}
+
+		foundComment.updateContent(request.getContent());
+		return CommentResponseDto.from(foundComment);
 	}
 
 	//이하 헬퍼 메서드

--- a/src/main/java/org/example/pdnight/domain/comment/service/CommentService.java
+++ b/src/main/java/org/example/pdnight/domain/comment/service/CommentService.java
@@ -1,17 +1,22 @@
 package org.example.pdnight.domain.comment.service;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.example.pdnight.domain.comment.dto.request.CommentRequestDto;
 import org.example.pdnight.domain.comment.dto.response.CommentResponseDto;
 import org.example.pdnight.domain.comment.entity.Comment;
 import org.example.pdnight.domain.comment.repository.CommentRepository;
+import org.example.pdnight.domain.common.dto.PagedResponse;
 import org.example.pdnight.domain.common.enums.ErrorCode;
 import org.example.pdnight.domain.common.exception.BaseException;
 import org.example.pdnight.domain.post.entity.Post;
 import org.example.pdnight.domain.post.repository.PostRepository;
 import org.example.pdnight.domain.user.entity.User;
 import org.example.pdnight.domain.user.repository.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -87,6 +92,41 @@ public class CommentService {
 		Comment savedChildComment = commentRepository.save(childComment);
 
 		return CommentResponseDto.from(savedChildComment);
+	}
+
+	//댓글 다건 조회 메서드 : 해당게시글의 댓글리스트
+	public PagedResponse<CommentResponseDto> getCommentsByPostId(Long postId, Pageable pageable) {
+		//파람값으로 넘어온 게시글이 존재하는지 확인
+		Post foundPost = getPostOrThrow(postRepository.findById(postId));
+
+		//1. 전체 댓글을 리스트로 반환 Id 기준으로 오름차순 정렬
+		List<Comment> foundComments = commentRepository.findByPostIdOrderByIdAsc(postId);
+
+		//2. Dto로 변환
+		List<CommentResponseDto> commentDtos = foundComments.stream().map(CommentResponseDto::from).toList();
+
+		//3. 부모 댓글 리스트만 걸러냄
+		List<CommentResponseDto> parentCommentDtos = commentDtos.stream()
+			.filter(commentDto -> commentDto.getParentId() == null)
+			.toList();
+
+		//4. 대댓글(자식댓글) 리스트 걸러냄
+		List<CommentResponseDto> childCommentDtos = commentDtos.stream()
+			.filter(commentDto -> commentDto.getParentId() != null)
+			.toList();
+
+		//5. 부모댓글을 순회 하는 반복문
+		for(CommentResponseDto parent : parentCommentDtos) {
+			//6. 자식 댓글을 순회해서 부모댓글 아이디와 자식댓글의 부모댓글 아이디가 일치하면 자식리스트에 추가
+			childCommentDtos.stream()
+				.filter(child -> parent.getId().equals(child.getParentId()))
+				.forEach(parent::addChild);
+		}
+
+		//7. 수동 페이징
+		Page<CommentResponseDto> pagedCommentDtos = new PageImpl<>(parentCommentDtos, pageable, parentCommentDtos.size());
+
+		return PagedResponse.from(pagedCommentDtos);
 	}
 
 	//이하 헬퍼 메서드

--- a/src/main/java/org/example/pdnight/domain/common/enums/ErrorCode.java
+++ b/src/main/java/org/example/pdnight/domain/common/enums/ErrorCode.java
@@ -48,6 +48,9 @@ public enum ErrorCode {
 
     // 댓글 관련 에러 (400 Bad Request,  404 NOT_FOUND)
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다"),
+    COMMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "작성자만 접근할 수 있습니다."),
+    POST_NOT_MATCHED(HttpStatus.CONFLICT, "댓글이 해당 게시글에 속하지 않습니다."),
+    INVALID_COMMENT_DEPTH(HttpStatus.BAD_REQUEST, "대댓글에는 대댓글을 달 수 없습니다."),
 
     // 입력값 검증 에러 (400 Bad Request)
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다"),

--- a/src/test/java/org/example/pdnight/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/org/example/pdnight/domain/comment/service/CommentServiceTest.java
@@ -1,0 +1,307 @@
+package org.example.pdnight.domain.comment.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.example.pdnight.domain.comment.dto.request.CommentRequestDto;
+import org.example.pdnight.domain.comment.dto.response.CommentResponseDto;
+import org.example.pdnight.domain.comment.entity.Comment;
+import org.example.pdnight.domain.comment.repository.CommentRepository;
+import org.example.pdnight.domain.common.dto.PagedResponse;
+import org.example.pdnight.domain.common.enums.ErrorCode;
+import org.example.pdnight.domain.common.exception.BaseException;
+import org.example.pdnight.domain.post.entity.Post;
+import org.example.pdnight.domain.post.repository.PostRepository;
+import org.example.pdnight.domain.user.entity.User;
+import org.example.pdnight.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+
+	@Mock
+	private CommentRepository commentRepository;
+
+	@Mock
+	private PostRepository postRepository;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@InjectMocks
+	private CommentService commentService;
+
+	private User mockUser;
+	private Post mockPost;
+	private Long postId;
+	private Long authorId;
+	private Long commentId;
+
+	@BeforeEach
+	void setUp() {
+		mockUser = Mockito.mock(User.class);
+		mockPost = Mockito.mock(Post.class);
+
+		lenient().when(mockUser.getId()).thenReturn(1L);
+		lenient().when(mockPost.getId()).thenReturn(1L);
+	}
+
+	@Test
+	@DisplayName("댓글 정상 생성 테스트")
+	void createComment_댓글_생성_성공() {
+		//given
+		postId = 1L;
+		authorId = 1L;
+		String content = "댓글내용";
+		CommentRequestDto request = new CommentRequestDto(content);
+
+		when(postRepository.findById(postId)).thenReturn(Optional.of(mockPost));
+		when(userRepository.findByIdAndIsDeletedFalse(authorId)).thenReturn(Optional.of(mockUser));
+
+		Comment comment = Comment.create(mockPost, mockUser, request.getContent());
+		when(commentRepository.save(any(Comment.class))).thenReturn(comment);
+
+		//when
+		CommentResponseDto result = commentService.createComment(postId, authorId, request);
+
+		//then
+		assertEquals(result.getAuthorId(), mockUser.getId());
+		assertEquals(result.getPostId(), mockPost.getId());
+		assertEquals(result.getContent(), request.getContent());
+
+		verify(postRepository).findById(postId);
+		verify(userRepository).findByIdAndIsDeletedFalse(authorId);
+		verify(commentRepository).save(any(Comment.class));
+	}
+
+	@Test
+	@DisplayName("게시물이 없어서 예외 발생 테스트")
+	void createComment_게시물_없음_생성_실패() {
+		//given
+		postId = 1L;
+		authorId = 1L;
+		String content = "댓글내용";
+		CommentRequestDto request = new CommentRequestDto(content);
+
+		when(postRepository.findById(postId)).thenReturn(Optional.empty());
+
+		//when & then
+		BaseException exception = assertThrows(BaseException.class, () ->
+			commentService.createComment(postId, authorId, request));
+
+		assertEquals(ErrorCode.POST_NOT_FOUND.getMessage(), exception.getMessage());
+
+		verify(postRepository).findById(postId);
+	}
+
+	@Test
+	@DisplayName("댓글 정상 삭제 테스트")
+	void deleteCommentById_댓글_삭제_성공() {
+		//given
+		postId = 1L;
+		commentId = 1L;
+		authorId = 1L;
+
+		String content = "댓글내용";
+		Comment comment = Comment.create(mockPost, mockUser, content);
+
+		when(postRepository.findById(postId)).thenReturn(Optional.of(mockPost));
+		when(userRepository.findByIdAndIsDeletedFalse(authorId)).thenReturn(Optional.of(mockUser));
+		when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+
+		//when & then
+		commentService.deleteCommentById(postId, commentId, authorId);
+
+		verify(postRepository).findById(postId);
+		verify(userRepository).findByIdAndIsDeletedFalse(authorId);
+		verify(commentRepository).findById(commentId);
+		verify(commentRepository).delete(comment);
+	}
+
+	@Test
+	@DisplayName("댓글 작성자가 아니라 삭제 시 예외 발생 테스트")
+	void deleteCommentById_작성자가_아닌_댓글_삭제_실패() {
+		//given
+		postId = 1L;
+		commentId = 1L;
+		authorId = 10L;
+		String content = "댓글내용";
+		Comment comment = Comment.create(mockPost, mockUser, content);
+
+		User anotherUser = Mockito.mock(User.class);
+		lenient().when(anotherUser.getId()).thenReturn(10L);
+
+		when(postRepository.findById(postId)).thenReturn(Optional.of(mockPost));
+		when(userRepository.findByIdAndIsDeletedFalse(authorId)).thenReturn(Optional.of(anotherUser));
+		when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+
+		//when & then
+		BaseException exception = assertThrows(BaseException.class, () ->
+			commentService.deleteCommentById(postId, commentId, authorId));
+
+		assertEquals(ErrorCode.COMMENT_FORBIDDEN.getMessage(), exception.getMessage());
+
+		verify(postRepository).findById(postId);
+		verify(userRepository).findByIdAndIsDeletedFalse(authorId);
+		verify(commentRepository).findById(commentId);
+	}
+
+	@Test
+	@DisplayName("댓글 정상 수정 테스트")
+	void updateCommentByDto_댓글_수정_성공() {
+		//given
+		postId = 1L;
+		commentId = 1L;
+		authorId = 1L;
+		String oldContent = "댓글내용";
+		Comment comment = Comment.create(mockPost, mockUser, oldContent);
+		CommentRequestDto request = new CommentRequestDto("수정할 댓글내용");
+
+		when(postRepository.findById(postId)).thenReturn(Optional.of(mockPost));
+		when(userRepository.findByIdAndIsDeletedFalse(authorId)).thenReturn(Optional.of(mockUser));
+		when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+
+		//when
+		CommentResponseDto response = commentService.updateCommentByDto(postId, commentId, authorId, request);
+
+		//then
+		assertEquals(request.getContent(), response.getContent());
+		assertNotEquals(oldContent, response.getContent());
+
+		verify(postRepository).findById(postId);
+		verify(userRepository).findByIdAndIsDeletedFalse(authorId);
+		verify(commentRepository).findById(commentId);
+	}
+
+	@Test
+	@DisplayName("댓글 작성자가 아니라 수정 시 예외 발생 테스트")
+	void updateCommentByDto_작성자가_아닌_댓글_수정_실패() {
+		//given
+		postId = 1L;
+		commentId = 1L;
+		authorId = 10L;
+		String oldContent = "댓글내용";
+		Comment comment = Comment.create(mockPost, mockUser, oldContent);
+		CommentRequestDto request = new CommentRequestDto("수정할 댓글내용");
+
+		User anotherUser = Mockito.mock(User.class);
+		lenient().when(anotherUser.getId()).thenReturn(10L);
+
+		when(postRepository.findById(postId)).thenReturn(Optional.of(mockPost));
+		when(userRepository.findByIdAndIsDeletedFalse(authorId)).thenReturn(Optional.of(anotherUser));
+		when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+
+		//when & then
+		BaseException exception = assertThrows(BaseException.class, () ->
+			commentService.deleteCommentById(postId, commentId, authorId));
+
+		verify(postRepository).findById(postId);
+		verify(userRepository).findByIdAndIsDeletedFalse(authorId);
+		verify(commentRepository).findById(commentId);
+	}
+
+	@Test
+	@DisplayName("대댓글 정상 생성 테스트")
+	void createChildComment_대댓글_생성_성공() {
+		//given
+		postId = 1L;
+		commentId = 1L;
+		authorId = 1L;
+		String content = "댓글내용";
+		CommentRequestDto request = new CommentRequestDto(content);
+
+		Comment parentComment = Comment.create(mockPost, mockUser, request.getContent());
+		Comment childComment = Comment.createChild(mockPost, mockUser, request.getContent(), parentComment);
+
+		when(postRepository.findById(postId)).thenReturn(Optional.of(mockPost));
+		when(userRepository.findByIdAndIsDeletedFalse(authorId)).thenReturn(Optional.of(mockUser));
+		when(commentRepository.findById(commentId)).thenReturn(Optional.of(parentComment));
+		when(commentRepository.save(any(Comment.class))).thenReturn(childComment);
+
+		//when
+		CommentResponseDto result = commentService.createChildComment(postId, commentId, authorId, request);
+
+		//then
+		assertEquals(result.getAuthorId(), mockUser.getId());
+		assertEquals(result.getPostId(), mockPost.getId());
+		assertEquals(result.getContent(), request.getContent());
+		assertEquals(result.getParentId(), parentComment.getId());
+
+		verify(postRepository).findById(postId);
+		verify(userRepository).findByIdAndIsDeletedFalse(authorId);
+		verify(commentRepository).findById(commentId);
+		verify(commentRepository).save(any(Comment.class));
+	}
+
+	@Test
+	@DisplayName("댓글 다건조회 정상 반환 확인 테스트")
+	void getCommentsByPostId_댓글_다건조회_정상구조() {
+		//given
+		postId = 1L;
+		Pageable pageable = PageRequest.of(0, 10);
+
+		when(postRepository.findById(postId)).thenReturn(Optional.of(mockPost));
+
+		Comment parentComment1 = Comment.create(mockPost, mockUser, "부모댓글1");
+		Comment parentComment2 = Comment.create(mockPost, mockUser, "부모댓글2");
+		Comment childComment = Comment.createChild(mockPost, mockUser, "자식댓글1", parentComment1);
+
+		//Id 직접 세팅
+		ReflectionTestUtils.setField(parentComment1, "id", 1L);
+		ReflectionTestUtils.setField(parentComment2, "id", 2L);
+		ReflectionTestUtils.setField(childComment, "id", 3L);
+
+		//반환 리스트 세팅
+		List<Comment> commentList = List.of(parentComment1, parentComment2, childComment);
+
+		when(commentRepository.findByPostIdOrderByIdAsc(postId)).thenReturn(commentList);
+
+		//when
+		PagedResponse<CommentResponseDto> response = commentService.getCommentsByPostId(postId, pageable);
+
+		//then
+		List<CommentResponseDto> contents = response.contents();
+
+		//부모댓글만 저장되니 size == 2
+		assertEquals(2, contents.size());
+
+		//1번 부모댓글엔 자식댓글 하나가 저장됐으니 size == 1
+		assertEquals(1, contents.get(0).getChildren().size());
+
+		//꺼낸 자식댓글의 아이디와 저장시킨 자식댓글 아이디 비교
+		assertEquals(contents.get(0).getChildren().get(0).getId(), childComment.getId());
+
+		verify(commentRepository).findByPostIdOrderByIdAsc(postId);
+	}
+
+	@Test
+	@DisplayName("게시글 없어서 예외 발생 테스트")
+	void getCommentsByPostId_게시글_없어서_조회_실패() {
+		//given
+		postId = 1L;
+		Pageable pageable = PageRequest.of(0, 10);
+
+		when(postRepository.findById(postId)).thenReturn(Optional.empty());
+
+		//when & then
+		BaseException exception = assertThrows(BaseException.class, () ->
+			commentService.getCommentsByPostId(postId, pageable));
+
+		assertEquals(ErrorCode.POST_NOT_FOUND.getMessage(), exception.getMessage());
+
+		verify(postRepository).findById(postId);
+	}
+}


### PR DESCRIPTION
### 댓글 도메인 기능 구현
---
### 구현 사항
- 댓글 추가 기능
- 댓글 수정 기능
- 댓글 삭제 기능
- 대댓글 추가 기능
- 댓글 다건 조회 기능
---
### 상세 내용
- 댓글은 Comment.create, 대댓글은 Comment.createChild 메서드를 통해 생성
- 대댓글 생성 시 CommentResponseDto에 부모댓글 id 포함하여 반환
- 댓글 다건 조회 시 CommentResponseDto에 자식 댓글 리스트 포함하여 트리구조로 반환
---
### 기타 이슈
- 테스트 코드 모두 작성 및 통과 확인