### PR TITLE
Feat/post delete fk error

### DIFF
--- a/src/main/java/org/example/pdnight/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/org/example/pdnight/domain/comment/repository/CommentRepository.java
@@ -1,10 +1,24 @@
 package org.example.pdnight.domain.comment.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.example.pdnight.domain.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 	List<Comment> findByPostIdOrderByIdAsc(Long postId);
+
+	//해당 게시글의 자식댓글 일괄 삭제
+	@Modifying
+	@Query("delete from Comment c where c.post.id = :postId and c.parent is not null")
+	void deleteAllByChildrenPostId(@Param("postId") Long postId);
+
+	//해당 게시글의 부모댓글 일괄 삭제
+	@Modifying
+	@Query("delete from Comment c where c.post.id = :postId and c.parent is null")
+	void deleteAllByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/org/example/pdnight/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/example/pdnight/domain/post/repository/PostRepository.java
@@ -16,4 +16,5 @@ public interface PostRepository extends JpaRepository<Post, Long>{
 	//상태값 조건 쿼리메서드
 	Optional<Post> findByIdAndStatus(Long id, PostStatus status);
 
+	boolean existsById(Long id);
 }

--- a/src/main/java/org/example/pdnight/domain/post/service/PostService.java
+++ b/src/main/java/org/example/pdnight/domain/post/service/PostService.java
@@ -2,6 +2,7 @@ package org.example.pdnight.domain.post.service;
 
 import java.util.Optional;
 
+import org.example.pdnight.domain.comment.repository.CommentRepository;
 import org.example.pdnight.domain.common.dto.PagedResponse;
 import org.example.pdnight.domain.common.enums.ErrorCode;
 import org.example.pdnight.domain.common.enums.JobCategory;
@@ -34,6 +35,7 @@ public class PostService {
 	private final PostRepository postRepository;
 	private final UserRepository userRepository;
 	private final PostRepositoryQuery PostRepositoryQuery;
+	private final CommentRepository commentRepository;
 
 	//포스트 작성
 	@Transactional
@@ -69,6 +71,11 @@ public class PostService {
 		validateAuthor(userId, foundPost);
 
 		foundPost.unlinkReviews();
+
+		//자식 댓글들 먼저 일괄 삭제 외래키 제약 제거
+		commentRepository.deleteAllByChildrenPostId(id);
+		//postId 기준 댓글 일괄 삭제 메서드 외래키 제약 제거
+		commentRepository.deleteAllByPostId(id);
 		postRepository.delete(foundPost);
 	}
 

--- a/src/main/java/org/example/pdnight/domain/user/entity/User.java
+++ b/src/main/java/org/example/pdnight/domain/user/entity/User.java
@@ -134,6 +134,13 @@ public class User extends Timestamped {
         this.deletedAt = null;
     }
 
+    //어드민 생성 메서드
+    public static User createAdmin(String email, String name, String password) {
+        User admin = new User(email, name, password);
+        admin.role = UserRole.ADMIN;
+        return admin;
+    }
+
     public void softDelete() {
         isDeleted = true;
         deletedAt = LocalDateTime.now();

--- a/src/main/java/org/example/pdnight/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/pdnight/domain/user/repository/UserRepository.java
@@ -15,5 +15,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByIdAndIsDeletedFalse(Long id);  
   
     Optional<User> findByEmail(String email);
+
+	boolean existsByEmail(String email);
   
 }

--- a/src/main/java/org/example/pdnight/global/init/AdminAccountInitializer.java
+++ b/src/main/java/org/example/pdnight/global/init/AdminAccountInitializer.java
@@ -1,0 +1,33 @@
+package org.example.pdnight.global.init;
+
+import org.example.pdnight.domain.user.entity.User;
+import org.example.pdnight.domain.user.repository.UserRepository;
+import org.example.pdnight.global.config.PasswordEncoder;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AdminAccountInitializer implements ApplicationRunner {
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	@Override
+	public void run(ApplicationArguments args) throws Exception {
+		String adminEmail = "admin@pdnight.com";
+		String adminName = "관리자";
+		String adminPassword = passwordEncoder.encode("password1!");
+
+		//이미 admin 계정이 있을 시
+		if (userRepository.existsByEmail(adminEmail)) {
+			return;
+		}
+
+		User admin = User.createAdmin(adminEmail, adminName, adminPassword);
+		userRepository.save(admin);
+	}
+
+}


### PR DESCRIPTION
### 게시글 도메인 오류 수정
---
### 구현 사항
- 댓글 추가로 인한 제약조건 문제 해결
- 대댓글 삭제 -> 댓글 삭제 -> 게시글 삭제 순으로 로직 변경
- 관리자 생성 기능 추가
---
### 상세 내용
- 댓글 기능이 casecade 로 해결할 수 없는 로직이라 순차적으로 삭제해야함
- global/init
ㄴAdminAccountInitializer
    - 어드민 계정 이닛 클래스
    - 프로젝트 시작 시 Admin계정 바로 생성
    - 이메일 검증을 통해 중복계정 생성 방지
