### PR TITLE
fix: User 조회시 패치조인이 적용안된 것 변경

### DIFF
--- a/src/main/java/org/example/pdnight/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/pdnight/domain/user/repository/UserRepository.java
@@ -3,6 +3,7 @@ package org.example.pdnight.domain.user.repository;
 import org.example.pdnight.domain.user.entity.User;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -18,6 +19,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // 취미, 기술스택을 사용할 때
     @EntityGraph(attributePaths = {"userHobbies.hobby", "userTechs.techStack"})
-    Optional<User> findUserById(Long id);
+    @Query("SELECT u FROM User u WHERE u.id = :id")
+    Optional<User> findByIdWithInfo(Long id);
 
 }

--- a/src/main/java/org/example/pdnight/domain/user/service/UserService.java
+++ b/src/main/java/org/example/pdnight/domain/user/service/UserService.java
@@ -39,7 +39,7 @@ public class UserService {
     public UserResponseDto getMyProfile(Long userId) {
 
         // id로 유저 조회
-        User user = getUserById(userId);
+        User user = getUserByIdWithInfo(userId);
 
         // UserResponseDto로 변환하여 반환
         return UserResponseDto.from(user);
@@ -47,7 +47,7 @@ public class UserService {
 
     @Transactional
     public UserResponseDto updateMyProfile(Long userId, UserUpdateRequest request) {
-        User user = getUserById(userId);
+        User user = getUserByIdWithInfo(userId);
 
         // Set<UserHobby> / Set<UserTech> 생성 : DB 에서 있는거만 가져오기
         Set<UserHobby> userHobbies = getUserHobbyByIdList(request.getHobbyIdList(), user);
@@ -76,7 +76,7 @@ public class UserService {
 
     public UserResponseDto getProfile(Long userId) {
         // id로 유저 조회
-        User user = getUserById(userId);
+        User user = getUserByIdWithInfo(userId);
 
         // UserResponseDto로 변환하여 반환
         return UserResponseDto.from(user);
@@ -102,6 +102,11 @@ public class UserService {
     // get
     private User getUserById(Long id) {
         return userRepository.findById(id).orElseThrow(
+                () -> new BaseException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private User getUserByIdWithInfo(Long id) {
+        return userRepository.findByIdWithInfo(id).orElseThrow(
                 () -> new BaseException(ErrorCode.USER_NOT_FOUND));
     }
 


### PR DESCRIPTION
리펙토링 과정에서 적용이 빠짐

findByIdWithInfo
- 취미, 기술스택을 조회할 때 사용

사용 경우
- 내 프로필 조회
- 프로필 업데이트
- 유저 프로필 조회