### PR TITLE
feat: post tag랑 tag 추가

### DIFF
--- a/src/main/java/org/example/pdnight/domain/post/application/PostUseCase/PostCommanderService.java
+++ b/src/main/java/org/example/pdnight/domain/post/application/PostUseCase/PostCommanderService.java
@@ -35,6 +35,7 @@ public class PostCommanderService {
     private final PostCommander postCommander;
     private final PostProducer postProducer;
     private final UserPort userPort;
+    private final PostInfoAssembler postInfoAssembler;
 
     // region  게시물
     @Transactional
@@ -54,7 +55,8 @@ public class PostCommanderService {
                 request.getGenderLimit(),
                 request.getJobCategoryLimit(),
                 request.getAgeLimit(),
-                request.isFirstCome()
+                request.isFirstCome(),
+                request.getTagIdList()
         );
 
         postCommander.save(post);
@@ -65,7 +67,7 @@ public class PostCommanderService {
             Long authorId = post.getAuthorId();
             postProducer.produce("followee.post.created", new FolloweePostCreatedEvent(authorId, post.getId(), followeeIds));
         }
-        return PostResponse.toDto(post);
+        return postInfoAssembler.toDto(post);
     }
 
     // 논리적 삭제
@@ -133,10 +135,11 @@ public class PostCommanderService {
                 request.getMaxParticipants(),
                 request.getGenderLimit(),
                 request.getJobCategoryLimit(),
-                request.getAgeLimit()
+                request.getAgeLimit(),
+                request.getTagIdList()
         );
 
-        return PostResponse.toDto(foundPost);
+        return postInfoAssembler.toDto(foundPost);
     }
 
     @Transactional
@@ -177,7 +180,7 @@ public class PostCommanderService {
             }
         }
 
-        return PostResponse.toDto(foundPost);
+        return postInfoAssembler.toDto(foundPost);
     }
 
     @Transactional

--- a/src/main/java/org/example/pdnight/domain/post/application/PostUseCase/PostInfoAssembler.java
+++ b/src/main/java/org/example/pdnight/domain/post/application/PostUseCase/PostInfoAssembler.java
@@ -1,0 +1,90 @@
+package org.example.pdnight.domain.post.application.PostUseCase;
+
+import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.post.domain.post.Post;
+import org.example.pdnight.domain.post.domain.post.PostTag;
+import org.example.pdnight.domain.post.domain.tag.TagReader;
+import org.example.pdnight.domain.post.presentation.dto.response.PostInfo;
+import org.example.pdnight.domain.post.presentation.dto.response.PostResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class PostInfoAssembler {
+
+    private final TagReader tagReader;
+
+    public PostResponse toDto(Post post) {
+        List<Long> tagIdList = post.getPostTagList().stream()
+                .map(PostTag::getTagId)
+                .toList();
+
+        List<String> tagNameList = tagReader.getNamesByIds(tagIdList);
+
+        return PostResponse.from(post, tagNameList);
+    }
+
+    public PostResponse toDtoWithCount(Post post, int acceptedParticipantsCount, int participantsCount) {
+        List<Long> tagIdList = post.getPostTagList().stream()
+                .map(PostTag::getTagId)
+                .toList();
+
+        List<String> tagNameList = tagReader.getNamesByIds(tagIdList);
+
+        return PostResponse.toDtoWithCount(post, tagNameList, acceptedParticipantsCount, participantsCount);
+    }
+
+
+    public PostInfo toInfoDto(Post post) {
+        List<Long> tagIdList = post.getPostTagList().stream()
+                .map(PostTag::getTagId)
+                .toList();
+
+        List<String> tagNameList = tagReader.getNamesByIds(tagIdList);
+
+        return PostInfo.toDto(
+                post.getId(),
+                post.getAuthorId(),
+                post.getTitle(),
+                post.getTimeSlot(),
+                post.getPublicContent(),
+                post.getStatus(),
+                post.getMaxParticipants(),
+                post.getGenderLimit(),
+                post.getJobCategoryLimit(),
+                tagNameList,
+                post.getAgeLimit(),
+                post.getIsFirstCome(),
+                post.getCreatedAt(),
+                post.getUpdatedAt()
+        );
+    }
+
+    //toDto
+    public List<PostResponse> toDtoList(Page<Post> page) {
+        List<Post> posts = page.getContent();
+
+        Set<Long> tagIdList = posts.stream()
+                .flatMap(p -> p.getPostTagList().stream())
+                .map(PostTag::getTagId)
+                .collect(Collectors.toSet());
+
+        Map<Long, String> tagMap = tagReader.getNamesByIdsMap(tagIdList);
+
+        return posts.stream()
+                .map(post -> {
+                    List<String> tagNameList = post.getPostTagList().stream()
+                            .map(pt -> tagMap.getOrDefault(pt.getTagId(), ""))
+                            .toList();
+
+                    return PostResponse.from(post, tagNameList);
+                })
+                .toList();
+    }
+}

--- a/src/main/java/org/example/pdnight/domain/post/application/PostUseCase/PostReaderService.java
+++ b/src/main/java/org/example/pdnight/domain/post/application/PostUseCase/PostReaderService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.pdnight.domain.post.domain.post.Post;
 import org.example.pdnight.domain.post.domain.post.PostParticipant;
 import org.example.pdnight.domain.post.domain.post.PostReader;
+import org.example.pdnight.domain.post.domain.post.PostTag;
 import org.example.pdnight.domain.post.enums.AgeLimit;
 import org.example.pdnight.domain.post.enums.Gender;
 import org.example.pdnight.domain.post.enums.JoinStatus;
@@ -22,15 +23,14 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
-
 
 @Service
 @RequiredArgsConstructor
 public class PostReaderService {
 
     private final PostReader postReader;
+    private final TagPort tagPort;
 
     //region 게시글 조회
     // 게시글 단건 조회
@@ -38,8 +38,14 @@ public class PostReaderService {
     @Cacheable(value = CacheName.ONE_POST, key = "#id")
     public PostResponse findPost(Long id) {
         Post foundPost = getPost(id);
+        // 참여자 수 조회
         int participants = acceptedParticipantsCounter(foundPost.getPostParticipants());
-        return PostResponse.toDtoWithCount(foundPost, participants, foundPost.getPostParticipants().size());
+
+        // 태그 리스트 조회 - 게시글의 태그 Id 들로 이름 검색
+        List<Long> tagIdList = foundPost.getPostTagList().stream().map(PostTag::getTagId).toList();
+        List<String> tagNames = tagPort.findAllTagNames(tagIdList);
+
+        return PostResponse.toDtoWithCount(foundPost, tagNames, participants, foundPost.getPostParticipants().size());
     }
 
     //게시물 조건 검색
@@ -57,9 +63,16 @@ public class PostReaderService {
     ) {
         Page<Post> postSearch = postReader.findPostsBySearch(pageable, maxParticipants,
                 ageLimit, jobCategoryLimit, genderLimit);
+
+        // Page<PostResponse> 매핑
         Page<PostResponse> postDtosBySearch = postSearch.map(search -> {
+            // 태그 리스트 조회 - 게시글의 태그 Id 들로 이름 검색
+            List<Long> tagIds = search.getPostTagList().stream().map(PostTag::getTagId).toList();
+            List<String> tagNames = tagPort.findAllTagNames(tagIds);
+
+            // 참여자 수 조회
             int participantCount = acceptedParticipantsCounter(search.getPostParticipants());
-            return PostResponse.toDtoWithCount(search, participantCount, search.getPostParticipants().size());
+            return PostResponse.toDtoWithCount(search, tagNames, participantCount, search.getPostParticipants().size());
         });
         return PagedResponse.from(postDtosBySearch);
     }
@@ -81,9 +94,16 @@ public class PostReaderService {
     )
     public PagedResponse<PostResponse> findMyWrittenPosts(Long userId, Pageable pageable) {
         Page<Post> postSearch = postReader.getWrittenPost(userId, pageable);
+
+        // Page<PostResponse> 매핑
         Page<PostResponse> myLikePost = postSearch.map(search -> {
+            // 태그 리스트 조회 - 게시글의 태그 Id 들로 이름 검색
+            List<Long> tagIds = search.getPostTagList().stream().map(PostTag::getTagId).toList();
+            List<String> tagNames = tagPort.findAllTagNames(tagIds);
+
+            // 참여자 수 조회
             int participantCount = acceptedParticipantsCounter(search.getPostParticipants());
-            return PostResponse.toDtoWithCount(search, participantCount, search.getPostParticipants().size());
+            return PostResponse.toDtoWithCount(search, tagNames, participantCount, search.getPostParticipants().size());
         });
 
         return PagedResponse.from(myLikePost);
@@ -96,9 +116,16 @@ public class PostReaderService {
     )
     public PagedResponse<PostResponse> getSuggestedPosts(Long userId, Pageable pageable) {
         Page<Post> postSearch = postReader.getSuggestedPost(userId, pageable);
+
+        // Page<PostResponse> 매핑
         Page<PostResponse> suggestedPost = postSearch.map(search -> {
+            // 태그 리스트 조회 - 게시글의 태그 Id 들로 이름 검색
+            List<Long> tagIds = search.getPostTagList().stream().map(PostTag::getTagId).toList();
+            List<String> tagNames = tagPort.findAllTagNames(tagIds);
+
+            // 참여자 수 조회
             int participantCount = acceptedParticipantsCounter(search.getPostParticipants());
-            return PostResponse.toDtoWithCount(search, participantCount, search.getPostParticipants().size());
+            return PostResponse.toDtoWithCount(search, tagNames, participantCount, search.getPostParticipants().size());
         });
         return PagedResponse.from(suggestedPost);
     }

--- a/src/main/java/org/example/pdnight/domain/post/application/PostUseCase/TagPort.java
+++ b/src/main/java/org/example/pdnight/domain/post/application/PostUseCase/TagPort.java
@@ -1,0 +1,11 @@
+package org.example.pdnight.domain.post.application.PostUseCase;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public interface TagPort {
+
+    List<String> findAllTagNames(List<Long> tagIdList);
+}

--- a/src/main/java/org/example/pdnight/domain/post/application/tagUseCase/TagCommanderService.java
+++ b/src/main/java/org/example/pdnight/domain/post/application/tagUseCase/TagCommanderService.java
@@ -1,0 +1,37 @@
+package org.example.pdnight.domain.post.application.tagUseCase;
+
+import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.post.domain.tag.Tag;
+import org.example.pdnight.domain.post.domain.tag.TagCommander;
+import org.example.pdnight.domain.post.presentation.dto.request.TagRequest;
+import org.example.pdnight.domain.post.presentation.dto.response.TagResponse;
+import org.example.pdnight.global.common.enums.ErrorCode;
+import org.example.pdnight.global.common.exception.BaseException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class TagCommanderService {
+
+    private final TagCommander tagCommander;
+
+    @Transactional
+    public TagResponse createTag(TagRequest dto) {
+        validateExistTag(dto);
+
+        Tag tag = Tag.create(dto.getTagName());
+
+        Tag save = tagCommander.save(tag);
+        return TagResponse.from(save);
+    }
+
+    // ----------------------------------- HELPER 메서드 ------------------------------------------------------ //
+    // validate
+    private void validateExistTag(TagRequest dto) {
+        boolean exists = tagCommander.existsTagByName(dto.getTagName());
+        if (exists) {
+            throw new BaseException(ErrorCode.TAG_ALREADY_EXISTS);
+        }
+    }
+}

--- a/src/main/java/org/example/pdnight/domain/post/application/tagUseCase/TagReaderService.java
+++ b/src/main/java/org/example/pdnight/domain/post/application/tagUseCase/TagReaderService.java
@@ -1,0 +1,25 @@
+package org.example.pdnight.domain.post.application.tagUseCase;
+
+import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.post.domain.tag.Tag;
+import org.example.pdnight.domain.post.domain.tag.TagReader;
+import org.example.pdnight.domain.post.presentation.dto.response.TagResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class TagReaderService {
+
+    private final TagReader tagReader;
+
+    @Transactional(readOnly = true)
+    public List<TagResponse> searchTags(String tagName) {
+        List<Tag> tagList = tagReader.searchTags(tagName);
+        return tagList.stream()
+                .map(TagResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/org/example/pdnight/domain/post/application/tagUseCase/TagService.java
+++ b/src/main/java/org/example/pdnight/domain/post/application/tagUseCase/TagService.java
@@ -1,0 +1,14 @@
+package org.example.pdnight.domain.post.application.tagUseCase;
+
+import org.example.pdnight.domain.post.presentation.dto.request.TagRequest;
+import org.example.pdnight.domain.post.presentation.dto.response.TagResponse;
+
+import java.util.List;
+
+public interface TagService {
+
+    TagResponse createTag(TagRequest tagRequest);
+
+    List<TagResponse> searchTagList(String tag);
+
+}

--- a/src/main/java/org/example/pdnight/domain/post/application/tagUseCase/TagServiceImpl.java
+++ b/src/main/java/org/example/pdnight/domain/post/application/tagUseCase/TagServiceImpl.java
@@ -1,0 +1,26 @@
+package org.example.pdnight.domain.post.application.tagUseCase;
+
+import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.post.presentation.dto.request.TagRequest;
+import org.example.pdnight.domain.post.presentation.dto.response.TagResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TagServiceImpl implements TagService {
+
+    private final TagCommanderService commanderService;
+    private final TagReaderService readerService;
+
+    @Override
+    public TagResponse createTag(TagRequest tagRequest) {
+        return commanderService.createTag(tagRequest);
+    }
+
+    @Override
+    public List<TagResponse> searchTagList(String tag) {
+        return readerService.searchTags(tag);
+    }
+}

--- a/src/main/java/org/example/pdnight/domain/post/domain/post/Post.java
+++ b/src/main/java/org/example/pdnight/domain/post/domain/post/Post.java
@@ -64,6 +64,8 @@ public class Post extends Timestamped {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Invite> invites = new ArrayList<>();
 
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostTag> postTagList = new ArrayList<>();
 
     private Boolean isDeleted = false;
     private LocalDateTime deletedAt;
@@ -77,7 +79,8 @@ public class Post extends Timestamped {
             Gender genderLimit,
             JobCategory jobCategoryLimit,
             AgeLimit ageLimit,
-            Boolean isFirstCome
+            Boolean isFirstCome,
+            List<Long> tagIdList
     ) {
         this.authorId = authorId;
         this.title = title;
@@ -85,16 +88,11 @@ public class Post extends Timestamped {
         this.publicContent = publicContent;
         this.status = PostStatus.OPEN;
         this.maxParticipants = maxParticipants;
-        if (genderLimit != null) {
-            this.genderLimit = genderLimit;
-        }
-        if (jobCategoryLimit != null) {
-            this.jobCategoryLimit = jobCategoryLimit;
-        }
-        if (ageLimit != null) {
-            this.ageLimit = ageLimit;
-        }
+        if (genderLimit != null) this.genderLimit = genderLimit;
+        if (jobCategoryLimit != null) this.jobCategoryLimit = jobCategoryLimit;
+        if (ageLimit != null) this.ageLimit = ageLimit;
         this.isFirstCome = isFirstCome;
+        setPostTagList(tagIdList);
     }
 
     public static Post createPost(
@@ -106,7 +104,8 @@ public class Post extends Timestamped {
             Gender genderLimit,
             JobCategory jobCategoryLimit,
             AgeLimit ageLimit,
-            Boolean isFirstCome
+            Boolean isFirstCome,
+            List<Long> tagIdList
     ) {
         return new Post(
                 authorId,
@@ -117,7 +116,8 @@ public class Post extends Timestamped {
                 genderLimit,
                 jobCategoryLimit,
                 ageLimit,
-                isFirstCome
+                isFirstCome,
+                tagIdList
         );
     }
 
@@ -129,7 +129,8 @@ public class Post extends Timestamped {
             Integer maxParticipants,
             Gender genderLimit,
             JobCategory jobCategoryLimit,
-            AgeLimit ageLimit
+            AgeLimit ageLimit,
+            List<Long> tagIdList
     ) {
         if (title != null) this.title = title;
         if (timeSlot != null) this.timeSlot = timeSlot;
@@ -137,7 +138,16 @@ public class Post extends Timestamped {
         if (maxParticipants != null && maxParticipants >= 1) this.maxParticipants = maxParticipants;
         if (genderLimit != null) this.genderLimit = genderLimit;
         if (jobCategoryLimit != null) this.jobCategoryLimit = jobCategoryLimit;
+        if (postTagList != null) this.postTagList = postTagList;
         if (ageLimit != null) this.ageLimit = ageLimit;
+        this.postTagList.clear();
+        setPostTagList(tagIdList);
+    }
+
+    public void setPostTagList(List<Long> tagIdList) {
+        for (Long tagId : tagIdList) {
+            this.postTagList.add(PostTag.create(this, tagId));
+        }
     }
 
     //상태 변경 메서드

--- a/src/main/java/org/example/pdnight/domain/post/domain/post/PostTag.java
+++ b/src/main/java/org/example/pdnight/domain/post/domain/post/PostTag.java
@@ -1,0 +1,32 @@
+package org.example.pdnight.domain.post.domain.post;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "post_tags")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    private Long tagId;
+
+    public PostTag(Post post, Long tagId) {
+        this.post = post;
+        this.tagId = tagId;
+    }
+
+    public static PostTag create(Post post, Long tagId) {
+        return new PostTag(post, tagId);
+    }
+}

--- a/src/main/java/org/example/pdnight/domain/post/domain/tag/Tag.java
+++ b/src/main/java/org/example/pdnight/domain/post/domain/tag/Tag.java
@@ -1,0 +1,27 @@
+package org.example.pdnight.domain.post.domain.tag;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "tags")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Tag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", unique = true)
+    private String name;
+
+    private Tag(String tagName) {
+        this.name = tagName;
+    }
+
+    public static Tag create(String tagName) {
+        return new Tag(tagName);
+    }
+}

--- a/src/main/java/org/example/pdnight/domain/post/domain/tag/TagCommander.java
+++ b/src/main/java/org/example/pdnight/domain/post/domain/tag/TagCommander.java
@@ -1,0 +1,10 @@
+package org.example.pdnight.domain.post.domain.tag;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public interface TagCommander {
+    Tag save(Tag tag);
+
+    boolean existsTagByName(String tagName);
+}

--- a/src/main/java/org/example/pdnight/domain/post/domain/tag/TagReader.java
+++ b/src/main/java/org/example/pdnight/domain/post/domain/tag/TagReader.java
@@ -1,0 +1,14 @@
+package org.example.pdnight.domain.post.domain.tag;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public interface TagReader {
+
+    List<String> getNamesByIds(List<Long> tagIdList);
+
+    Map<Long, String> getNamesByIdsMap(Set<Long> tagIdList);
+
+    List<Tag> searchTags(String tagName);
+}

--- a/src/main/java/org/example/pdnight/domain/post/infra/comment/PostAdapter.java
+++ b/src/main/java/org/example/pdnight/domain/post/infra/comment/PostAdapter.java
@@ -1,6 +1,7 @@
 package org.example.pdnight.domain.post.infra.comment;
 
 import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.post.application.PostUseCase.PostInfoAssembler;
 import org.example.pdnight.domain.post.application.commentUseCase.PostPort;
 import org.example.pdnight.domain.post.domain.post.Post;
 import org.example.pdnight.domain.post.domain.post.PostCommander;
@@ -16,27 +17,14 @@ public class PostAdapter implements PostPort {
 
     private final PostReader postReader;
     private final PostCommander postCommander;
+    private final PostInfoAssembler postInfoAssembler;
 
     @Override
     public PostInfo findById(Long postId) {
         Post post = postReader.findById(postId)
                 .orElseThrow(() -> new BaseException(ErrorCode.POST_NOT_FOUND));
 
-        return PostInfo.toDto(
-                post.getId(),
-                post.getAuthorId(),
-                post.getTitle(),
-                post.getTimeSlot(),
-                post.getPublicContent(),
-                post.getStatus(),
-                post.getMaxParticipants(),
-                post.getGenderLimit(),
-                post.getJobCategoryLimit(),
-                post.getAgeLimit(),
-                post.getIsFirstCome(),
-                post.getCreatedAt(),
-                post.getUpdatedAt()
-        );
+        return postInfoAssembler.toInfoDto(post);
     }
 
     @Override

--- a/src/main/java/org/example/pdnight/domain/post/infra/post/TagAdaptor.java
+++ b/src/main/java/org/example/pdnight/domain/post/infra/post/TagAdaptor.java
@@ -1,0 +1,20 @@
+package org.example.pdnight.domain.post.infra.post;
+
+import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.post.application.PostUseCase.TagPort;
+import org.example.pdnight.domain.post.domain.tag.TagReader;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class TagAdaptor implements TagPort {
+
+    private final TagReader tagReader;
+
+    @Override
+    public List<String> findAllTagNames(List<Long> tagIdList) {
+        return tagReader.getNamesByIds(tagIdList);
+    }
+}

--- a/src/main/java/org/example/pdnight/domain/post/infra/tag/TagCommanderImpl.java
+++ b/src/main/java/org/example/pdnight/domain/post/infra/tag/TagCommanderImpl.java
@@ -1,0 +1,21 @@
+package org.example.pdnight.domain.post.infra.tag;
+
+import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.post.domain.tag.TagCommander;
+import org.springframework.stereotype.Component;
+import org.example.pdnight.domain.post.domain.tag.Tag;
+
+@Component
+@RequiredArgsConstructor
+public class TagCommanderImpl implements TagCommander {
+    private final TagJpaRepository tagJpaRepository;
+
+    public Tag save(Tag tag){
+        return tagJpaRepository.save(tag);
+    }
+
+    @Override
+    public boolean existsTagByName(String tagName) {
+        return  tagJpaRepository.existsTagByName(tagName);
+    }
+}

--- a/src/main/java/org/example/pdnight/domain/post/infra/tag/TagJpaRepository.java
+++ b/src/main/java/org/example/pdnight/domain/post/infra/tag/TagJpaRepository.java
@@ -1,0 +1,8 @@
+package org.example.pdnight.domain.post.infra.tag;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.example.pdnight.domain.post.domain.tag.Tag;
+
+public interface TagJpaRepository extends JpaRepository<Tag, Long> {
+    boolean existsTagByName(final String name);
+}

--- a/src/main/java/org/example/pdnight/domain/post/infra/tag/TagReaderImpl.java
+++ b/src/main/java/org/example/pdnight/domain/post/infra/tag/TagReaderImpl.java
@@ -1,0 +1,59 @@
+package org.example.pdnight.domain.post.infra.tag;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.post.domain.tag.QTag;
+import org.example.pdnight.domain.post.domain.tag.Tag;
+import org.example.pdnight.domain.post.domain.tag.TagReader;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class TagReaderImpl implements TagReader {
+
+    private final JPAQueryFactory queryFactory;
+
+    QTag qTag = QTag.tag;
+
+    @Override
+    public List<Tag> searchTags(String tagName) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (StringUtils.hasText(tagName)) {
+            builder.and(qTag.name.contains(tagName));
+        }
+        return queryFactory.selectFrom(qTag)
+                .where(builder).fetch();
+    }
+
+
+    @Override
+    public List<String> getNamesByIds(List<Long> tagIdList) {
+        if (tagIdList == null || tagIdList.isEmpty()) return List.of();
+
+        return queryFactory
+                .select(qTag.name)
+                .from(qTag)
+                .where(qTag.id.in(tagIdList))
+                .fetch();
+    }
+
+    @Override
+    public Map<Long, String> getNamesByIdsMap(Set<Long> tagIdList) {
+        if (tagIdList == null || tagIdList.isEmpty()) return Map.of();
+
+        return queryFactory
+                .selectFrom(qTag)
+                .where(qTag.id.in(tagIdList))
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(Tag::getId, Tag::getName));
+    }
+}

--- a/src/main/java/org/example/pdnight/domain/post/presentation/TagController.java
+++ b/src/main/java/org/example/pdnight/domain/post/presentation/TagController.java
@@ -1,0 +1,37 @@
+package org.example.pdnight.domain.post.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.example.pdnight.domain.post.application.tagUseCase.TagService;
+import org.example.pdnight.domain.post.presentation.dto.request.TagRequest;
+import org.example.pdnight.domain.post.presentation.dto.response.TagResponse;
+import org.example.pdnight.global.common.dto.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/tags")
+@RequiredArgsConstructor
+public class TagController {
+    private final TagService tagService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<TagResponse>> createTag(
+            @Validated @RequestBody TagRequest dto
+    ) {
+        TagResponse tagResponse = tagService.createTag(dto);
+        System.out.println(dto.getTagName());
+
+        return ResponseEntity.ok(ApiResponse.ok("태그가 성공적으로 생성 되었습니다", tagResponse));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<TagResponse>>> searchTags(
+            @RequestParam(required = false) String tagName
+    ) {
+        List<TagResponse> tagResponsesList = tagService.searchTagList(tagName);
+        return ResponseEntity.ok(ApiResponse.ok("태그 검색에 성공했습니다!", tagResponsesList));
+    }
+}

--- a/src/main/java/org/example/pdnight/domain/post/presentation/dto/request/PostRequest.java
+++ b/src/main/java/org/example/pdnight/domain/post/presentation/dto/request/PostRequest.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import org.example.pdnight.domain.post.enums.AgeLimit;
 import org.example.pdnight.domain.post.enums.Gender;
 import org.example.pdnight.global.common.enums.JobCategory;
-
+import java.util.List;
 import java.time.LocalDateTime;
 
 @Getter
@@ -32,5 +32,5 @@ public class PostRequest {
     private JobCategory jobCategoryLimit;
     private AgeLimit ageLimit;
     private boolean isFirstCome;
-
+    private List<Long> tagIdList;
 }

--- a/src/main/java/org/example/pdnight/domain/post/presentation/dto/request/PostUpdateRequest.java
+++ b/src/main/java/org/example/pdnight/domain/post/presentation/dto/request/PostUpdateRequest.java
@@ -28,7 +28,5 @@ public class PostUpdateRequest {
     private JobCategory jobCategoryLimit;
     private AgeLimit ageLimit;
 
-    private List<Long> hobbyIdList;
-    private List<Long> techStackIdList;
-
+    private List<Long> tagIdList;
 }

--- a/src/main/java/org/example/pdnight/domain/post/presentation/dto/request/TagRequest.java
+++ b/src/main/java/org/example/pdnight/domain/post/presentation/dto/request/TagRequest.java
@@ -1,0 +1,14 @@
+package org.example.pdnight.domain.post.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TagRequest {
+    @NotNull
+    private String tagName;
+}

--- a/src/main/java/org/example/pdnight/domain/post/presentation/dto/response/PostInfo.java
+++ b/src/main/java/org/example/pdnight/domain/post/presentation/dto/response/PostInfo.java
@@ -7,6 +7,7 @@ import org.example.pdnight.domain.post.enums.PostStatus;
 import org.example.pdnight.global.common.enums.JobCategory;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 public class PostInfo {
@@ -19,6 +20,7 @@ public class PostInfo {
     private Integer maxParticipants;
     private Gender genderLimit;
     private JobCategory jobCategoryLimit;
+    private List<String> tagList;
     private AgeLimit ageLimit;
     private boolean isFirstCome;
     private LocalDateTime createdAt;
@@ -34,6 +36,7 @@ public class PostInfo {
             Integer maxParticipants,
             Gender genderLimit,
             JobCategory jobCategoryLimit,
+            List<String> tagList,
             AgeLimit ageLimit,
             boolean isFirstCome,
             LocalDateTime createdAt,
@@ -48,6 +51,7 @@ public class PostInfo {
         this.maxParticipants = maxParticipants;
         this.genderLimit = genderLimit;
         this.jobCategoryLimit = jobCategoryLimit;
+        this.tagList = tagList;
         this.ageLimit = ageLimit;
         this.isFirstCome = isFirstCome;
         this.createdAt = createdAt;
@@ -64,6 +68,7 @@ public class PostInfo {
             Integer maxParticipants,
             Gender genderLimit,
             JobCategory jobCategoryLimit,
+            List<String> tagList,
             AgeLimit ageLimit,
             boolean isFirstCome,
             LocalDateTime createdAt,
@@ -79,6 +84,7 @@ public class PostInfo {
                 maxParticipants,
                 genderLimit,
                 jobCategoryLimit,
+                tagList,
                 ageLimit,
                 isFirstCome,
                 createdAt,

--- a/src/main/java/org/example/pdnight/domain/post/presentation/dto/response/PostResponse.java
+++ b/src/main/java/org/example/pdnight/domain/post/presentation/dto/response/PostResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.example.pdnight.domain.post.domain.post.Post;
 import org.example.pdnight.domain.post.enums.AgeLimit;
 import org.example.pdnight.domain.post.enums.Gender;
@@ -12,6 +13,7 @@ import org.example.pdnight.domain.post.enums.PostStatus;
 import org.example.pdnight.global.common.enums.JobCategory;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -27,6 +29,8 @@ public class PostResponse {
     private final Integer maxParticipants;
     private final Gender genderLimit;
     private final JobCategory jobCategoryLimit;
+    @Setter
+    private List<String> tagList;
     private final AgeLimit ageLimit;
     private Integer acceptedParticipantsCount;
     private Integer participantsCount;
@@ -36,7 +40,7 @@ public class PostResponse {
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    private PostResponse(Post post) {
+    private PostResponse(Post post, List<String> tagNameList) {
         this.postId = post.getId();
         this.authorId = post.getAuthorId();
         this.title = post.getTitle();
@@ -46,13 +50,14 @@ public class PostResponse {
         this.maxParticipants = post.getMaxParticipants();
         this.genderLimit = post.getGenderLimit();
         this.jobCategoryLimit = post.getJobCategoryLimit();
+        this.tagList = tagNameList;
         this.ageLimit = post.getAgeLimit();
         this.isFirstCome = post.getIsFirstCome();
         this.createdAt = post.getCreatedAt();
         this.updatedAt = post.getUpdatedAt();
     }
 
-    private PostResponse(Post post, Integer acceptedParticipantsCount, Integer participantsCount) {
+    private PostResponse(Post post, List<String> postTags, Integer acceptedParticipantsCount, Integer participantsCount) {
         this.postId = post.getId();
         this.authorId = post.getAuthorId();
         this.title = post.getTitle();
@@ -62,6 +67,7 @@ public class PostResponse {
         this.maxParticipants = post.getMaxParticipants();
         this.genderLimit = post.getGenderLimit();
         this.jobCategoryLimit = post.getJobCategoryLimit();
+        this.tagList = postTags;
         this.ageLimit = post.getAgeLimit();
         this.isFirstCome = post.getIsFirstCome();
         this.acceptedParticipantsCount = acceptedParticipantsCount;
@@ -70,12 +76,12 @@ public class PostResponse {
         this.updatedAt = post.getUpdatedAt();
     }
 
-    public static PostResponse toDto(Post post) {
-        return new PostResponse(post);
+    public static PostResponse toDtoWithCount(Post post, List<String> postTags, int acceptedParticipantsCount, int participantsCount) {
+        return new PostResponse(post, postTags, acceptedParticipantsCount, participantsCount);
     }
 
-    public static PostResponse toDtoWithCount(Post post, int acceptedParticipantsCount, int participantsCount) {
-        return new PostResponse(post, acceptedParticipantsCount, participantsCount);
+    public static PostResponse from(Post post, List<String> tagNameList) {
+        return new PostResponse(post, tagNameList);
     }
 
     @QueryProjection

--- a/src/main/java/org/example/pdnight/domain/post/presentation/dto/response/TagResponse.java
+++ b/src/main/java/org/example/pdnight/domain/post/presentation/dto/response/TagResponse.java
@@ -1,0 +1,18 @@
+package org.example.pdnight.domain.post.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.pdnight.domain.post.domain.tag.Tag;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TagResponse {
+    private Long id;
+    private String tagName;
+
+    public static TagResponse from(Tag tag){
+        return new TagResponse(tag.getId(), tag.getName());
+    }
+}

--- a/src/main/java/org/example/pdnight/domain/user/domain/teckStackDomain/TechStackReader.java
+++ b/src/main/java/org/example/pdnight/domain/user/domain/teckStackDomain/TechStackReader.java
@@ -1,9 +1,7 @@
 package org.example.pdnight.domain.user.domain.teckStackDomain;
 
-import jakarta.validation.constraints.NotNull;
 import org.example.pdnight.domain.user.domain.entity.TechStack;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -11,12 +9,6 @@ import java.util.Set;
 public interface TechStackReader {
 
     List<TechStack> searchTechStack(String techStack);
-
-    Collection<TechStack> findByIdList(List<Long> ids);
-
-    boolean existsTechStackByTechStack(@NotNull String techStack);
-
-    TechStack findByTechStack(String techStack);
 
     List<String> getNamesByIds(List<Long> techIds);
 

--- a/src/main/java/org/example/pdnight/domain/user/infra/techStackInfra/TechStackReaderImpl.java
+++ b/src/main/java/org/example/pdnight/domain/user/infra/techStackInfra/TechStackReaderImpl.java
@@ -36,34 +36,6 @@ public class TechStackReaderImpl implements TechStackReader {
     }
 
     @Override
-    public List<TechStack> findByIdList(List<Long> ids) {
-        return queryFactory.selectFrom(qTechStack)
-                .where(qTechStack.id.in(ids))
-                .fetch();
-    }
-
-    @Override
-    public boolean existsTechStackByTechStack(String techStack) {
-
-        Integer result = queryFactory
-                .selectOne()
-                .from(qTechStack)
-                .where(qTechStack.techStack.eq(techStack))
-                .fetchFirst();
-        return result != null;
-    }
-
-    @Override
-    public TechStack findByTechStack(String techStack) {
-        QTechStack qTechStack = QTechStack.techStack1;
-
-        return queryFactory
-                .selectFrom(qTechStack)
-                .where(qTechStack.techStack.eq(techStack))
-                .fetchOne();
-    }
-
-    @Override
     public List<String> getNamesByIds(List<Long> techIds) {
 
         if (techIds == null || techIds.isEmpty()) return List.of();

--- a/src/main/java/org/example/pdnight/global/common/enums/ErrorCode.java
+++ b/src/main/java/org/example/pdnight/global/common/enums/ErrorCode.java
@@ -82,6 +82,10 @@ public enum ErrorCode {
     TECH_STACK_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 기술 스택입니다"),
     TECH_STACK_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 기술 스택입니다."),
 
+    //기술 스택 관련 오류
+    TAG_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 태그입니다"),
+    TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 태그 입니다."),
+
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 채팅방입니다."),
     CHAT_ROOM_NOT_PARTICIPANT(HttpStatus.FORBIDDEN, "참가 불가능한 채팅방입니다."),
 

--- a/src/test/java/org/example/pdnight/domain/post/application/PostUseCase/ParticipantServiceConcurrencyTest.java
+++ b/src/test/java/org/example/pdnight/domain/post/application/PostUseCase/ParticipantServiceConcurrencyTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -65,7 +66,8 @@ public class ParticipantServiceConcurrencyTest {
                 Gender.ALL,
                 JobCategory.ALL,
                 AgeLimit.ALL,
-                true
+                true,
+                Collections.emptyList()
         );
         firstComeTestPost = postCommander.save(firstComeTestPost);
 
@@ -79,7 +81,8 @@ public class ParticipantServiceConcurrencyTest {
                 Gender.ALL,
                 JobCategory.ALL,
                 AgeLimit.ALL,
-                false
+                false,
+                Collections.emptyList()
         );
         requestTestPost = postCommander.save(requestTestPost);
 
@@ -93,7 +96,8 @@ public class ParticipantServiceConcurrencyTest {
                 Gender.ALL,
                 JobCategory.ALL,
                 AgeLimit.ALL,
-                false
+                false,
+                Collections.emptyList()
         );
         InviteTestPost = postCommander.save(InviteTestPost);
     }

--- a/src/test/java/org/example/pdnight/domain/post/application/PostUseCase/PostReaderServiceTest.java
+++ b/src/test/java/org/example/pdnight/domain/post/application/PostUseCase/PostReaderServiceTest.java
@@ -42,6 +42,9 @@ class PostReaderServiceTest {
     @Mock
     private PostReader postReader;
 
+    @Mock
+    private TagPort tagPort;
+
     //region 게시글
     @Test
     @DisplayName("게시글 단건 조회 정상")


### PR DESCRIPTION
# PostTag 중간 테이블 도입 및 Tag 테이블 추가
- Tag 테이블 도입 하면서 기존의 기술스택과 취미와 같은 구조로 Controller 부터 Repository 까지 변경 했습니다
## Post Response 구조 변경
- 기존의 Response 에 추가적으로 Tag의 이름 String 값들이 들어간 List 가 응답에 추가 되었습니다
- 검색 성능 개선 팀은 그 부분 확인해서 진행 부탁 드립니다.
- 관련해서 API 명세는 아직 작성 안 되어 있는데 작성 되면 추후에 공지 하도록 하겠습니다.