### PR TITLE
Docs/springdoc open api 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,9 @@ dependencies {
 
     // Elasticsearch
     implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
+
+    // Springdoc OpenAPI
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/pdnight/domain/auth/presentation/controller/AuthController.java
+++ b/src/main/java/org/example/pdnight/domain/auth/presentation/controller/AuthController.java
@@ -1,5 +1,7 @@
 package org.example.pdnight.domain.auth.presentation.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +19,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Auth")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -25,6 +28,7 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/signup")
+    @Operation(summary = "회원가입", description = "사용자가 서비스에 가입한다")
     private ResponseEntity<ApiResponse<SignupResponse>> signup(@Valid @RequestBody SignupRequest request) {
         SignupResponse user = authService.signup(request);
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -32,6 +36,7 @@ public class AuthController {
     }
 
     @PostMapping("/login")
+    @Operation(summary = "로그인", description = "사용자가 서비스에 접속한다")
     private ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
         LoginResponse token = authService.login(request);
         return ResponseEntity.ok()
@@ -39,6 +44,7 @@ public class AuthController {
     }
 
     @PatchMapping("/password")
+    @Operation(summary = "비밀번호 변경", description = "본인의 비밀번호를 변경한다")
     public ResponseEntity<ApiResponse<Void>> updatePassword(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody UserPasswordUpdateRequest requestDto
@@ -53,12 +59,14 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "서비스를 접속 해제한다")
     private ResponseEntity<ApiResponse<Void>> logout(HttpServletRequest http) {
         authService.logout(http);
         return ResponseEntity.ok(ApiResponse.ok("로그아웃 되었습니다.", null));
     }
 
     @DeleteMapping("/withdraw")
+    @Operation(summary = "회원탈퇴", description = "사용자가 서비스를 탈퇴한다")
     private ResponseEntity<ApiResponse<Void>> withdraw(HttpServletRequest http,
                                                        @Valid @RequestBody WithdrawRequest request,
                                                        @AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/src/main/java/org/example/pdnight/domain/auth/presentation/dto/request/LoginRequest.java
+++ b/src/main/java/org/example/pdnight/domain/auth/presentation/dto/request/LoginRequest.java
@@ -1,5 +1,6 @@
 package org.example.pdnight.domain.auth.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,10 +10,12 @@ import org.example.pdnight.global.annotation.ValidEmailPattern;
 @Builder
 public class LoginRequest {
 
+    @Schema(example = "user1@naver.com")
     @NotBlank(message = "이메일은 작성해야 합니다.")
     @ValidEmailPattern
     private String email;
 
+    @Schema(example = "password1!")
     @NotBlank(message = "비밀번호를 작성해야 합니다.")
     private String password;
 

--- a/src/main/java/org/example/pdnight/domain/auth/presentation/dto/request/SignupRequest.java
+++ b/src/main/java/org/example/pdnight/domain/auth/presentation/dto/request/SignupRequest.java
@@ -1,5 +1,6 @@
 package org.example.pdnight.domain.auth.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -11,10 +12,12 @@ import org.example.pdnight.global.common.enums.JobCategory;
 @Getter
 @Builder
 public class SignupRequest {
+    @Schema(example = "user1@naver.com")
     @NotBlank(message = "이메일은 작성해야 합니다.")
     @ValidEmailPattern
     private String email;
 
+    @Schema(example = "password1!")
     @NotBlank(message = "비밀번호를 작성해야 합니다.")
     private String password;
 
@@ -27,6 +30,7 @@ public class SignupRequest {
     @NotNull(message = "성별을 작성해야 합니다.")
     private Gender gender;
 
+    @Schema(example = "30")
     @NotNull(message = "나이를 작성해야 합니다.")
     private Long age;
 

--- a/src/main/java/org/example/pdnight/domain/auth/presentation/dto/request/UserPasswordUpdateRequest.java
+++ b/src/main/java/org/example/pdnight/domain/auth/presentation/dto/request/UserPasswordUpdateRequest.java
@@ -1,12 +1,16 @@
 package org.example.pdnight.domain.auth.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class UserPasswordUpdateRequest {
+    @Schema(example = "password1!")
     @NotNull
     private String oldPassword;
+
+    @Schema(example = "password2!")
     @NotNull
     private String newPassword;
 }

--- a/src/main/java/org/example/pdnight/domain/auth/presentation/dto/request/WithdrawRequest.java
+++ b/src/main/java/org/example/pdnight/domain/auth/presentation/dto/request/WithdrawRequest.java
@@ -1,5 +1,6 @@
 package org.example.pdnight.domain.auth.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,6 +9,7 @@ import lombok.Getter;
 @Builder
 public class WithdrawRequest {
 
+    @Schema(example = "password1!")
     @NotBlank(message = "비밀번호를 작성해야 합니다.")
     private String password;
 

--- a/src/main/java/org/example/pdnight/domain/chat/presentation/ChatRoomController.java
+++ b/src/main/java/org/example/pdnight/domain/chat/presentation/ChatRoomController.java
@@ -1,5 +1,6 @@
 package org.example.pdnight.domain.chat.presentation;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.example.pdnight.domain.chat.application.chatRoomUseCase.ChatRoomService;
 import org.example.pdnight.domain.chat.domain.ChatRoom;
@@ -43,6 +44,7 @@ public class ChatRoomController {
     // 모든 채팅방 목록 반환
     @GetMapping("/chat/list")
     @ResponseBody
+    @Operation(summary = "채팅방 목록 조회", description = "채팅방 목록을 조회합니다", tags = {"Chat"})
     public ResponseEntity<ApiResponse<List<ChatRoomResponse>>> room() {
         return ResponseEntity.ok(ApiResponse.ok("채팅방 목록이 조회되었습니다.", chatRoomService.list()));
     }
@@ -50,6 +52,7 @@ public class ChatRoomController {
     // 채팅방 생성
     @PostMapping("/chat/room")
     @ResponseBody
+    @Operation(summary = "채팅방 생성", description = "채팅방을 생성합니다", tags = {"Chat"})
     public ResponseEntity<ApiResponse<ChatRoomResponse>> createRoom(@RequestParam String name) {
         ChatRoom chatRoom = chatRoomService.create(name);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse
@@ -59,6 +62,7 @@ public class ChatRoomController {
     // 특정 채팅방 정보 조회
     @GetMapping("/chat/room/{roomId}")
     @ResponseBody
+    @Operation(summary = "채팅방 정보 조회", description = "채팅방 정보를 조회합니다", tags = {"Chat"})
     public ResponseEntity<ApiResponse<ChatRoomResponse>> roomInfo(@PathVariable Long roomId) {
         return ResponseEntity.ok(ApiResponse.ok("채팅방 정보가 조회되었습니다.", chatRoomService.roomInfo(roomId)));
     }
@@ -66,6 +70,7 @@ public class ChatRoomController {
     // 채팅방 접속시 닉네임 정보 조회
     @GetMapping("/chat/enter/me")
     @ResponseBody
+    @Operation(summary = "본인 닉네임 조회", description = "본인의 닉네임을 조회합니다", tags = {"Chat"})
     public ResponseEntity<ApiResponse<NicknameResponse>> nicknameInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return ResponseEntity.ok(ApiResponse.ok("닉네임이 조회되었습니다", NicknameResponse.from(userDetails.getUsername())));
     }

--- a/src/main/java/org/example/pdnight/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/org/example/pdnight/domain/notification/presentation/NotificationController.java
@@ -1,5 +1,7 @@
 package org.example.pdnight.domain.notification.presentation;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.pdnight.domain.notification.application.notificationUseCase.NotificationService;
 import org.example.pdnight.domain.notification.presentation.dto.NotificationResponse;
@@ -12,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Notification")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/notification")
@@ -20,6 +23,7 @@ public class NotificationController {
     private final NotificationService notificationService;
 
     @PostMapping("/{id}")
+    @Operation(summary = "알림 읽음 확인", description = "받은 알림을 읽는다")
     public ResponseEntity<ApiResponse<NotificationResponse>> isRead(
             @PathVariable Long id,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -31,6 +35,7 @@ public class NotificationController {
 
     // 사용자의 모든 알림 조회
     @GetMapping("/all")
+    @Operation(summary = "모든 알림 조회", description = "사용자가 받은 알림 목록을 조회한다")
     public ResponseEntity<ApiResponse<PagedResponse<NotificationResponse>>> getNotifications(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(defaultValue = "0") int page,
@@ -44,6 +49,7 @@ public class NotificationController {
 
     // 사용자의 읽지 않은 알림 조회
     @GetMapping("/unread")
+    @Operation(summary = "읽지 않은 알림 조회", description = "사용자가 받은 알림 중 읽지 않은 알림 목록을 조회한다")
     public ResponseEntity<ApiResponse<PagedResponse<NotificationResponse>>> getIsReadFalseNotifications(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(defaultValue = "0") int page,

--- a/src/main/java/org/example/pdnight/domain/post/presentation/CommentController.java
+++ b/src/main/java/org/example/pdnight/domain/post/presentation/CommentController.java
@@ -1,5 +1,7 @@
 package org.example.pdnight.domain.post.presentation;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.pdnight.domain.post.application.commentUseCase.CommentService;
@@ -15,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Comment")
 @RestController
 @RequiredArgsConstructor
 public class CommentController {
@@ -23,6 +26,7 @@ public class CommentController {
 
     //댓글 다건조회 메서드
     @GetMapping("/api/posts/{postId}/comments")
+    @Operation(summary = "댓글 리스트 조회", description = "특정 게시글의 댓글 전체를 조회한다")
     public ResponseEntity<ApiResponse<PagedResponse<CommentResponse>>> getComments(
             @PathVariable Long postId,
             @RequestParam(defaultValue = "0") int page,
@@ -37,6 +41,7 @@ public class CommentController {
 
     //댓글 생성 메서드
     @PostMapping("/api/posts/{postId}/comments")
+    @Operation(summary = "댓글 등록", description = "특정 게시글에 댓글을 등록한다")
     public ResponseEntity<ApiResponse<CommentResponse>> saveComment(
             @PathVariable Long postId,
             @AuthenticationPrincipal CustomUserDetails loginUser,
@@ -51,6 +56,7 @@ public class CommentController {
 
     //댓글 수정 메서드
     @PatchMapping("/api/posts/{postId}/comments/{id}")
+    @Operation(summary = "댓글 수정", description = "댓글을 수정한다")
     public ResponseEntity<ApiResponse<CommentResponse>> updateComment(
             @PathVariable Long postId,
             @PathVariable Long id,
@@ -66,6 +72,7 @@ public class CommentController {
 
     //대댓글 생성 메서드
     @PostMapping("/api/posts/{postId}/comments/{id}/comments")
+    @Operation(summary = "대댓글 등록", description = "대댓글을 등록한다")
     public ResponseEntity<ApiResponse<CommentResponse>> saveChildComment(
             @PathVariable Long postId,
             @PathVariable Long id,
@@ -81,6 +88,7 @@ public class CommentController {
 
     //댓글 삭제 메서드
     @DeleteMapping("/api/posts/{postId}/comments/{id}")
+    @Operation(summary = "댓글 삭제", description = "댓글을 삭제한다")
     public ResponseEntity<ApiResponse<Void>> deleteComment(
             @PathVariable Long postId,
             @PathVariable Long id,
@@ -95,6 +103,7 @@ public class CommentController {
 
     //   ------ admin ------
     @DeleteMapping("/api/admin/posts/{postId}/comments/{id}")
+    @Operation(summary = "[관리자] 댓글 강제 삭제", description = "관리자가 댓글을 강제로 삭제한다")
     public ResponseEntity<ApiResponse<Void>> deleteAdminComment(
             @PathVariable Long postId,
             @PathVariable Long id,

--- a/src/main/java/org/example/pdnight/domain/post/presentation/PostController.java
+++ b/src/main/java/org/example/pdnight/domain/post/presentation/PostController.java
@@ -383,6 +383,7 @@ public class PostController {
 
     //게시물 단건 조회
     @GetMapping("/posts/{id}/ES")
+    @Operation(summary = "[ES] 게시글 단건 조회", description = "게시글 하나를 조회한다", tags = {"Post"})
     public ResponseEntity<ApiResponse<PostResponse>> getPostByIdES(@PathVariable Long id) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.ok("게시글이 조회되었습니다.", postService.findPostES(id)));
@@ -390,6 +391,7 @@ public class PostController {
 
     // 내가 작성한 게시글 조회
     @GetMapping("/my/written-posts/ES")
+    @Operation(summary = "[ES] 작성한 게시글 조회", description = "본인이 작성한 게시글 목록을 조회한다", tags = {"Post"})
     public ResponseEntity<ApiResponse<PagedResponse<PostResponse>>> getMyWrittenPostsES(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PageableDefault(size = 10, page = 0) Pageable pageable
@@ -404,6 +406,7 @@ public class PostController {
 
     // 내 좋아요 게시글 목록 조회
     @GetMapping("/my/likes/ES")
+    @Operation(summary = "[ES] 좋아요 게시글 조회", description = "본인이 좋아요한 게시글 목록을 조회한다", tags = {"Post"})
     public ResponseEntity<ApiResponse<PagedResponse<PostResponse>>> getMyLikedPostsES(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PageableDefault(size = 10, page = 0) Pageable pageable
@@ -415,6 +418,7 @@ public class PostController {
 
     //내 신청/성사된 게시글 조회
     @GetMapping("/my/confirmed-posts/ES")
+    @Operation(summary = "[ES] 신청/성사된 게시글 조회", description = "본인이 신청한/성사된 게시글 목록을 조회한다", tags = {"Post"})
     public ResponseEntity<ApiResponse<PagedResponse<PostResponse>>> getMyConfirmedPostsES(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(required = false) JoinStatus joinStatus,
@@ -427,6 +431,7 @@ public class PostController {
 
     // 게시물 조건 조회
     @GetMapping("/posts/ES")
+    @Operation(summary = "[ES] 게시글 검색 조회", description = "게시글 목록을 검색하거나, 전체 조회한다", tags = {"Post"})
     public ResponseEntity<ApiResponse<PagedResponse<PostResponse>>> searchPostsES(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
@@ -445,6 +450,7 @@ public class PostController {
 
     // 신청자 목록 조회
     @GetMapping("/posts/{postId}/participant/ES")
+    @Operation(summary = "[ES] 게시글 신청자 목록 조회", description = "본인 게시글에 신청한 사용자 목록을 조회한다", tags = {"Participate"})
     public ResponseEntity<ApiResponse<PagedResponse<ParticipantResponse>>> getPendingParticipantListES(
             @AuthenticationPrincipal CustomUserDetails author,
             @PathVariable Long postId,
@@ -458,6 +464,7 @@ public class PostController {
 
     // 참가자 목록 조회
     @GetMapping("/posts/{postId}/participate/confirmed/ES")
+    @Operation(summary = "[ES] 게시글 참가자 목록 조회", description = "본인 게시글에 참가한 사용자 목록을 조회한다", tags = {"Participate"})
     public ResponseEntity<ApiResponse<PagedResponse<ParticipantResponse>>> getAcceptedParticipantListES(
             @AuthenticationPrincipal CustomUserDetails loginUser,
             @PathVariable Long postId,
@@ -471,6 +478,7 @@ public class PostController {
 
     //내 초대받은 목록 조회
     @GetMapping("/my/invited/ES")
+    @Operation(summary = "[ES] 초대받은 목록 조회", description = "본인이 초대받은 목록을 조회한다", tags = {"Invite"})
     public ResponseEntity<ApiResponse<PagedResponse<InviteResponse>>> getMyInvitedES(
             @AuthenticationPrincipal CustomUserDetails loggedInUser,
             @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
@@ -484,6 +492,7 @@ public class PostController {
 
     //내가 보낸 초대 목록 조회
     @GetMapping("/my/invite/ES")
+    @Operation(summary = "[ES] 초대보낸 목록 조회", description = "본인이 초대한 목록을 조회한다", tags = {"Invite"})
     public ResponseEntity<ApiResponse<PagedResponse<InviteResponse>>> getMyInviteES(
             @AuthenticationPrincipal CustomUserDetails loggedInUser,
             @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC)

--- a/src/main/java/org/example/pdnight/domain/post/presentation/PostController.java
+++ b/src/main/java/org/example/pdnight/domain/post/presentation/PostController.java
@@ -1,5 +1,6 @@
 package org.example.pdnight.domain.post.presentation;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.pdnight.domain.post.application.PostUseCase.PostService;
@@ -37,8 +38,9 @@ public class PostController {
 
     //region 게시글
     //region 게시글 조회 제외 메서드들
-    // 게시물 생성
+    // 게시글 생성
     @PostMapping("/posts")
+    @Operation(summary = "게시글 등록", description = "게시글을 등록한다", tags = {"Post"})
     public ResponseEntity<ApiResponse<PostResponse>> savePost(
             @Valid @RequestBody PostRequest request,
             @AuthenticationPrincipal CustomUserDetails loginUser
@@ -48,8 +50,9 @@ public class PostController {
                 .body(ApiResponse.ok("정상적으로 등록되었습니다.", postService.createPost(userId, request)));
     }
 
-    // 게시물 수정
+    // 게시글 수정
     @PatchMapping("/posts/{id}")
+    @Operation(summary = "게시글 수정", description = "게시글을 수정한다", tags = {"Post"})
     public ResponseEntity<ApiResponse<PostResponse>> updatePost(
             @PathVariable Long id,
             @RequestBody PostUpdateRequest requestDto,
@@ -61,8 +64,9 @@ public class PostController {
                 .body(ApiResponse.ok("게시글이 수정되었습니다.", updatedPost));
     }
 
-    // 게시물 상태 수정
+    // 게시글 상태 수정
     @PatchMapping("/posts/{id}/status")
+    @Operation(summary = "게시글 상태 수정", description = "게시글 상태를 수정한다", tags = {"Post"})
     public ResponseEntity<ApiResponse<PostResponse>> updateStatus(
             @PathVariable Long id,
             @RequestBody PostStatusRequest requestDto,
@@ -74,8 +78,9 @@ public class PostController {
                 .body(ApiResponse.ok("게시글 상태가 수정되었습니다.", updatedPost));
     }
 
-    // 게시물 삭제
+    // 게시글 삭제
     @DeleteMapping("/posts/{id}")
+    @Operation(summary = "게시글 삭제", description = "게시글을 삭제한다", tags = {"Post"})
     public ResponseEntity<ApiResponse<Void>> deletePost(
             @PathVariable Long id,
             @AuthenticationPrincipal CustomUserDetails loginUser
@@ -86,8 +91,9 @@ public class PostController {
                 .body(ApiResponse.ok("게시글이 삭제되었습니다.", null));
     }
 
-    // 어드민 - 유저게시물 삭제
+    // 어드민 - 유저게시글 삭제
     @DeleteMapping("/admin/posts/{id}")
+    @Operation(summary = "[관리자] 게시글 강제 삭제", description = "관리자가 게시글을 강제로 삭제한다", tags = {"AdminPost"})
     public ResponseEntity<ApiResponse<Void>> deletePost(
             @PathVariable Long id
     ) {
@@ -97,9 +103,10 @@ public class PostController {
     }
 
     //endregion
-    //region 게시물조회
-    //추천 게시물 조회
+    //region 게시글조회
+    //추천 게시글 조회
     @GetMapping("/posts/suggested-posts")
+    @Operation(summary = "추천 게시글 조회", description = "추천 게시글 목록을 조회한다", tags = {"Post"})
     public ResponseEntity<ApiResponse<PagedResponse<PostResponse>>> suggestedPosts(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
@@ -114,6 +121,7 @@ public class PostController {
 
     // 내 좋아요 게시글 목록 조회
     @GetMapping("/my/likes")
+    @Operation(summary = "좋아요 게시글 조회", description = "본인이 좋아요한 게시글 목록을 조회한다", tags = {"Post"})
     public ResponseEntity<ApiResponse<PagedResponse<PostResponse>>> getMyLikedPosts(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PageableDefault(size = 10, page = 0) Pageable pageable
@@ -125,6 +133,7 @@ public class PostController {
 
     //내 신청/성사된 게시글 조회
     @GetMapping("/my/confirmed-posts")
+    @Operation(summary = "신청/성사된 게시글 조회", description = "본인이 신청한/성사된 게시글 목록을 조회한다", tags = {"Post"})
     public ResponseEntity<ApiResponse<PagedResponse<PostResponse>>> getMyConfirmedPosts(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(required = false) JoinStatus joinStatus,
@@ -135,8 +144,9 @@ public class PostController {
         return ResponseEntity.ok(ApiResponse.ok("참여 신청한 게시글 목록이 조회되었습니다.", myLikedPost));
     }
 
-    //게시물 단건 조회
+    //게시글 단건 조회
     @GetMapping("/posts/{id}")
+    @Operation(summary = "게시글 단건 조회", description = "게시글 하나를 조회한다", tags = {"Post"})
     public ResponseEntity<ApiResponse<PostResponse>> getPostById(@PathVariable Long id) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.ok("게시글이 조회되었습니다.", postService.findPost(id)));
@@ -144,17 +154,19 @@ public class PostController {
 
     // 내가 작성한 게시글 조회
     @GetMapping("/my/written-posts")
+    @Operation(summary = "작성한 게시글 조회", description = "본인이 작성한 게시글 목록을 조회한다", tags = {"Post"})
     public ResponseEntity<ApiResponse<PagedResponse<PostResponse>>> getMyWrittenPosts(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PageableDefault(size = 10, page = 0) Pageable pageable
     ) {
         Long id = userDetails.getUserId();
         PagedResponse<PostResponse> myLikedPost = postService.findMyWrittenPosts(id, pageable);
-        return ResponseEntity.ok(ApiResponse.ok("내가 작성 한 게시물이 조회되었습니다.", myLikedPost));
+        return ResponseEntity.ok(ApiResponse.ok("내가 작성 한 게시글이 조회되었습니다.", myLikedPost));
     }
 
-    // 게시물 조건 조회
+    // 게시글 조건 조회
     @GetMapping("/posts")
+    @Operation(summary = "게시글 검색 조회", description = "게시글 목록을 검색하거나, 전체 조회한다", tags = {"Post"})
     public ResponseEntity<ApiResponse<PagedResponse<PostResponse>>> searchPosts(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
@@ -175,8 +187,9 @@ public class PostController {
     //endregion
     //region 게시글신청자
     //region 게시글신청자 조회제외 메서드들
-    // 게시물 참여 신청
+    // 게시글 참여 신청
     @PostMapping("/posts/{postId}/participate")
+    @Operation(summary = "게시글 참여 신청", description = "게시글에 참여 신청한다", tags = {"Participate"})
     public ResponseEntity<ApiResponse<ParticipantResponse>> applyParticipant(
             @AuthenticationPrincipal CustomUserDetails loginUser,
             @PathVariable Long postId
@@ -190,8 +203,9 @@ public class PostController {
                 .body(ApiResponse.ok("참여 신청되었습니다.", response));
     }
 
-    // 게시물 신청 수락 or 거절
+    // 게시글 신청 수락 or 거절
     @PatchMapping("/posts/{postId}/participate/users/{userId}")
+    @Operation(summary = "게시글 신청 수락/거절", description = "게시글 신청자를 수락하거나 거절한다", tags = {"Participate"})
     public ResponseEntity<ApiResponse<ParticipantResponse>> changeStatusParticipant(
             @AuthenticationPrincipal CustomUserDetails author,
             @PathVariable Long postId,
@@ -204,8 +218,9 @@ public class PostController {
                 .body(ApiResponse.ok("신청자의 상태가 변경되었습니다.", response));
     }
 
-    // 게시물 참여 신청 삭제
+    // 게시글 참여 신청 삭제
     @DeleteMapping("/posts/{postId}/participate")
+    @Operation(summary = "게시글 신청 삭제", description = "본인이 참여 신청한 것을 취소한다", tags = {"Participate"})
     public ResponseEntity<ApiResponse<Void>> deleteParticipant(
             @AuthenticationPrincipal CustomUserDetails loginUser,
             @PathVariable Long postId
@@ -219,6 +234,7 @@ public class PostController {
     //region 게시글신청자 조회 메서드
     // 신청자 목록 조회
     @GetMapping("/posts/{postId}/participant")
+    @Operation(summary = "게시글 신청자 목록 조회", description = "본인 게시글에 신청한 사용자 목록을 조회한다", tags = {"Participate"})
     public ResponseEntity<ApiResponse<PagedResponse<ParticipantResponse>>> getPendingParticipantList(
             @AuthenticationPrincipal CustomUserDetails author,
             @PathVariable Long postId,
@@ -232,6 +248,7 @@ public class PostController {
 
     // 참가자 목록 조회
     @GetMapping("/posts/{postId}/participate/confirmed")
+    @Operation(summary = "게시글 참가자 목록 조회", description = "본인 게시글에 참가한 사용자 목록을 조회한다", tags = {"Participate"})
     public ResponseEntity<ApiResponse<PagedResponse<ParticipantResponse>>> getAcceptedParticipantList(
             @AuthenticationPrincipal CustomUserDetails loginUser,
             @PathVariable Long postId,
@@ -245,9 +262,10 @@ public class PostController {
 
     //endregion
     //endregion
-    //region 게시물좋아요
-    // 게시물 좋아요 생성
+    //region 게시글좋아요
+    // 게시글 좋아요 생성
     @PostMapping("/posts/{id}/likes")
+    @Operation(summary = "게시글 좋아요 추가", description = "게시글에 좋아요를 추가한다", tags = {"PostLike"})
     public ResponseEntity<ApiResponse<PostLikeResponse>> addLike(
             @PathVariable Long id,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -258,8 +276,9 @@ public class PostController {
                 .body(ApiResponse.ok("게시글 좋아요가 추가되었습니다.", dto));
     }
 
-    // 게시물 좋아요 삭제
+    // 게시글 좋아요 삭제
     @DeleteMapping("/posts/{id}/likes")
+    @Operation(summary = "게시글 좋아요 삭제", description = "게시글에 좋아요를 취소한다", tags = {"PostLike"})
     public ResponseEntity<ApiResponse<Void>> removeLike(
             @PathVariable Long id,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -270,10 +289,11 @@ public class PostController {
     }
 
     //endregion
-    //region 게시물초대
-    //region 게시물초대 조회 제외메서드
-    // 게시물초대 생성
+    //region 게시글초대
+    //region 게시글초대 조회 제외메서드
+    // 게시글 초대 생성
     @PostMapping("/posts/{postId}/users/{userId}/invite")
+    @Operation(summary = "게시글 초대", description = "본인 게시글에 상대방을 초대한다", tags = {"Invite"})
     public ResponseEntity<ApiResponse<InviteResponse>> inviteUser(
             @PathVariable Long postId,
             @PathVariable Long userId,
@@ -285,8 +305,9 @@ public class PostController {
         return ResponseEntity.created(location).body(ApiResponse.ok("초대가 완료되었습니다.", responseDto));
     }
 
-    // 게시물 초대 취소
+    // 게시글 초대 취소
     @DeleteMapping("/posts/{postId}/users/{userId}/invite")
+    @Operation(summary = "게시글 초대 취소", description = "본인 게시글에 초대한 것을 취소한다", tags = {"Invite"})
     public ResponseEntity<ApiResponse<Void>> deleteInvite(
             @PathVariable Long postId,
             @PathVariable Long userId,
@@ -299,9 +320,10 @@ public class PostController {
     }
 
     //endregion
-    //region 게시물초대 조회 메서드
+    //region 게시글초대 조회 메서드
     //내 초대받은 목록 조회
     @GetMapping("/my/invited")
+    @Operation(summary = "초대받은 목록 조회", description = "본인이 초대받은 목록을 조회한다", tags = {"Invite"})
     public ResponseEntity<ApiResponse<PagedResponse<InviteResponse>>> getMyInvited(
             @AuthenticationPrincipal CustomUserDetails loggedInUser,
             @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
@@ -315,6 +337,7 @@ public class PostController {
 
     //내가 보낸 초대 목록 조회
     @GetMapping("/my/invite")
+    @Operation(summary = "초대보낸 목록 조회", description = "본인이 초대한 목록을 조회한다", tags = {"Invite"})
     public ResponseEntity<ApiResponse<PagedResponse<InviteResponse>>> getMyInvite(
             @AuthenticationPrincipal CustomUserDetails loggedInUser,
             @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
@@ -328,6 +351,7 @@ public class PostController {
     //endregion
 
     @PostMapping("/post/{postId}/invite/accept")
+    @Operation(summary = "받은 초대 수락", description = "본인이 받은 초대를 수락한다", tags = {"Invite"})
     public ResponseEntity<ApiResponse<Void>> acceptForInvite(
             @PathVariable Long postId,
             @AuthenticationPrincipal CustomUserDetails loginUser
@@ -339,6 +363,7 @@ public class PostController {
     }
 
     @PostMapping("/post/{postId}/invite/reject")
+    @Operation(summary = "받은 초대 거절", description = "본인이 받은 초대를 거절한다", tags = {"Invite"})
     public ResponseEntity<ApiResponse<Void>> rejectForInvite(
             @PathVariable Long postId,
             @AuthenticationPrincipal CustomUserDetails loginUser

--- a/src/main/java/org/example/pdnight/domain/post/presentation/TagController.java
+++ b/src/main/java/org/example/pdnight/domain/post/presentation/TagController.java
@@ -1,5 +1,7 @@
 package org.example.pdnight.domain.post.presentation;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.pdnight.domain.post.application.tagUseCase.TagService;
 import org.example.pdnight.domain.post.presentation.dto.request.TagRequest;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "PostTag")
 @RestController
 @RequestMapping("/api/tags")
 @RequiredArgsConstructor
@@ -18,6 +21,7 @@ public class TagController {
     private final TagService tagService;
 
     @PostMapping
+    @Operation(summary = "태그 추가", description = "태그를 추가한다")
     public ResponseEntity<ApiResponse<TagResponse>> createTag(
             @Validated @RequestBody TagRequest dto
     ) {
@@ -28,6 +32,7 @@ public class TagController {
     }
 
     @GetMapping
+    @Operation(summary = "태그 조회", description = "태그 목록을 조회한다")
     public ResponseEntity<ApiResponse<List<TagResponse>>> searchTags(
             @RequestParam(required = false) String tagName
     ) {

--- a/src/main/java/org/example/pdnight/domain/post/presentation/dto/request/PostRequest.java
+++ b/src/main/java/org/example/pdnight/domain/post/presentation/dto/request/PostRequest.java
@@ -1,5 +1,6 @@
 package org.example.pdnight.domain.post.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -31,6 +32,8 @@ public class PostRequest {
     private Gender genderLimit;
     private JobCategory jobCategoryLimit;
     private AgeLimit ageLimit;
+
+    @Schema(description = "선착순 여부", example = "false")
     private boolean isFirstCome;
 
 }

--- a/src/main/java/org/example/pdnight/domain/post/presentation/dto/request/PostRequest.java
+++ b/src/main/java/org/example/pdnight/domain/post/presentation/dto/request/PostRequest.java
@@ -35,5 +35,7 @@ public class PostRequest {
 
     @Schema(description = "선착순 여부", example = "false")
     private boolean isFirstCome;
+
+    @Schema(description = "태그 ID 목록", example = "[1, 2]")
     private List<Long> tagIdList;
 }

--- a/src/main/java/org/example/pdnight/domain/post/presentation/dto/request/PostStatusRequest.java
+++ b/src/main/java/org/example/pdnight/domain/post/presentation/dto/request/PostStatusRequest.java
@@ -1,5 +1,6 @@
 package org.example.pdnight.domain.post.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,6 +10,7 @@ import org.example.pdnight.domain.post.enums.PostStatus;
 @AllArgsConstructor
 public class PostStatusRequest {
 
+    @Schema(example = "CONFIRMED")
     @NotBlank(message = "변경할 상태값은 필수입력값입니다.")
     private PostStatus status;
 

--- a/src/main/java/org/example/pdnight/domain/post/presentation/dto/request/PostUpdateRequest.java
+++ b/src/main/java/org/example/pdnight/domain/post/presentation/dto/request/PostUpdateRequest.java
@@ -1,11 +1,11 @@
 package org.example.pdnight.domain.post.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.example.pdnight.domain.post.enums.AgeLimit;
 import org.example.pdnight.domain.post.enums.Gender;
-import org.example.pdnight.domain.post.enums.PostStatus;
 import org.example.pdnight.global.common.enums.JobCategory;
 
 import java.time.LocalDateTime;
@@ -20,9 +20,8 @@ public class PostUpdateRequest {
     private String title;
     private LocalDateTime timeSlot;
     private String publicContent;
-    private PostStatus status;
-
     //maxParticipants 는 1인 이상 검증해야함
+    @Schema(description = "참가자", example = "2")
     private Integer maxParticipants;
     private Gender genderLimit;
     private JobCategory jobCategoryLimit;

--- a/src/main/java/org/example/pdnight/domain/post/presentation/dto/request/TagRequest.java
+++ b/src/main/java/org/example/pdnight/domain/post/presentation/dto/request/TagRequest.java
@@ -1,5 +1,6 @@
 package org.example.pdnight.domain.post.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class TagRequest {
+    @Schema(description = "태그 이름", example = "Java")
     @NotNull
     private String tagName;
 }

--- a/src/main/java/org/example/pdnight/domain/promotion/presentation/controller/PromotionController.java
+++ b/src/main/java/org/example/pdnight/domain/promotion/presentation/controller/PromotionController.java
@@ -1,5 +1,6 @@
 package org.example.pdnight.domain.promotion.presentation.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.example.pdnight.domain.promotion.application.promotionUseCase.PromotionService;
 import org.example.pdnight.domain.promotion.presentation.dto.request.PromotionCreateRequest;
@@ -24,6 +25,7 @@ public class PromotionController {
 
     // 프로모션 조회
     @GetMapping("/promotions/{id}")
+    @Operation(summary = "프로모션 조회", description = "프로모션 하나를 조회한다", tags = {"Promotion"})
     public ResponseEntity<ApiResponse<PromotionResponse>> findPromotionById(
             @PathVariable Long id
     ) {
@@ -34,6 +36,7 @@ public class PromotionController {
 
     // 프로모션 리스트 조회
     @GetMapping("/promotions")
+    @Operation(summary = "프로모션 목록 조회", description = "프로모션 목록을 조회한다", tags = {"Promotion"})
     public ResponseEntity<ApiResponse<PagedResponse<PromotionResponse>>> findPromotionById(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
@@ -46,6 +49,7 @@ public class PromotionController {
 
     // 프로모션 참가 신청
     @PostMapping("/promotions/{id}/participants")
+    @Operation(summary = "프로모션 참가 신청", description = "특정 프로모션에 참가 신청한다", tags = {"Promotion"})
     public ResponseEntity<ApiResponse<Void>> addParticipant(
             @PathVariable Long id,
             @AuthenticationPrincipal CustomUserDetails loginUser
@@ -59,6 +63,7 @@ public class PromotionController {
 
     // 내가 참가한 프로모션 조회
     @GetMapping("/my/participant-promotions")
+    @Operation(summary = "참가한 프로모션 조회", description = "본인이 참가한 프로모션 목록을 조회한다", tags = {"Promotion"})
     public ResponseEntity<ApiResponse<PagedResponse<PromotionResponse>>> getMyParticipantPromotions(
             @AuthenticationPrincipal CustomUserDetails loginUser,
             @PageableDefault() Pageable pageable
@@ -74,6 +79,7 @@ public class PromotionController {
 
     // 프로모션 생성
     @PostMapping("/admin/promotions")
+    @Operation(summary = "[관리자] 프로모션 생성", description = "관리자가 프로모션을 생성한다", tags = {"AdminPromotion"})
     public ResponseEntity<ApiResponse<PromotionResponse>> createPromotion(
             @RequestBody PromotionCreateRequest request
     ) {
@@ -84,6 +90,7 @@ public class PromotionController {
 
     // 프로모션 수정
     @PatchMapping("/admin/promotions/{id}")
+    @Operation(summary = "[관리자] 프로모션 수정", description = "관리자가 프로모션을 수정한다", tags = {"AdminPromotion"})
     public ResponseEntity<ApiResponse<PromotionResponse>> updatePromotion(
             @PathVariable Long id,
             @RequestBody PromotionCreateRequest request
@@ -95,6 +102,7 @@ public class PromotionController {
 
     // 프로모션 삭제
     @DeleteMapping("/admin/promotions/{id}")
+    @Operation(summary = "[관리자] 프로모션 삭제", description = "관리자가 프로모션을 삭제한다", tags = {"AdminPromotion"})
     public ResponseEntity<ApiResponse<Void>> deletePromotion(
             @PathVariable Long id
     ) {
@@ -106,6 +114,7 @@ public class PromotionController {
 
     // 프로모션 참가 인원 리스트 조회
     @GetMapping("/admin/promotions/{id}/participants")
+    @Operation(summary = "[관리자] 프로모션 참가자 조회", description = "관리자가 프로모션에 참가한 사용자들을 조회한다", tags = {"AdminPromotion"})
     public ResponseEntity<ApiResponse<PagedResponse<PromotionParticipantResponse>>> getPromotionParticipants(
             @PathVariable Long id,
             @RequestParam(defaultValue = "0") int page,

--- a/src/main/java/org/example/pdnight/domain/promotion/presentation/dto/request/PromotionCreateRequest.java
+++ b/src/main/java/org/example/pdnight/domain/promotion/presentation/dto/request/PromotionCreateRequest.java
@@ -1,5 +1,6 @@
 package org.example.pdnight.domain.promotion.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -14,6 +15,7 @@ public class PromotionCreateRequest {
     @NotBlank(message = "내용은 필수 입력값입니다.")
     private String content;
 
+    @Schema(example = "2")
     @NotNull(message = "정원은 필수 입력값입니다.")
     private Integer maxParticipants;
 

--- a/src/main/java/org/example/pdnight/domain/user/presentation/controller/CouponController.java
+++ b/src/main/java/org/example/pdnight/domain/user/presentation/controller/CouponController.java
@@ -1,5 +1,7 @@
 package org.example.pdnight.domain.user.presentation.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.pdnight.domain.user.application.couponUseCase.CouponService;
 import org.example.pdnight.domain.user.presentation.dto.couponDto.request.CouponRequest;
@@ -11,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "AdminCoupon")
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
@@ -22,18 +25,21 @@ public class CouponController {
 
     // 쿠폰 생성
     @PostMapping("/admin/coupons")
+    @Operation(summary = "[관리자] 쿠폰 생성", description = "관리자가 쿠폰을 등록합니다.")
     public ResponseEntity<ApiResponse<CouponResponse>> createCoupon(@Validated @RequestBody CouponRequest dto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok("쿠폰이 등록되었습니다.", couponService.createCoupon(dto)));
     }
 
     // 쿠폰 수정
     @PatchMapping("/admin/coupons/{id}")
+    @Operation(summary = "[관리자] 쿠폰 수정", description = "관리자가 쿠폰을 수정합니다.")
     public ResponseEntity<ApiResponse<CouponResponse>> updateCoupon(@PathVariable Long id, @RequestBody UpdateCouponRequest dto) {
         return ResponseEntity.ok(ApiResponse.ok("쿠폰이 수정되었습니다.", couponService.updateCoupon(id, dto)));
     }
 
     // 쿠폰 삭제
     @DeleteMapping("/admin/coupons/{id}")
+    @Operation(summary = "[관리자] 쿠폰 삭제", description = "관리자가 쿠폰을 삭제합니다.")
     public ResponseEntity<ApiResponse<Void>> deleteCoupon(@PathVariable Long id) {
         couponService.deleteCoupon(id);
         return ResponseEntity.ok(ApiResponse.ok("쿠폰이 삭제되었습니다.", null));
@@ -44,6 +50,7 @@ public class CouponController {
 
     // 쿠폰 조회
     @GetMapping("/admin/coupons/{id}")
+    @Operation(summary = "[관리자] 쿠폰 조회", description = "관리자가 쿠폰을 조회합니다.")
     public ResponseEntity<ApiResponse<CouponResponse>> getCoupon(@PathVariable Long id) {
         return ResponseEntity.ok(ApiResponse.ok("쿠폰이 조회되었습니다.", couponService.getCoupon(id)));
     }

--- a/src/main/java/org/example/pdnight/domain/user/presentation/controller/HobbyController.java
+++ b/src/main/java/org/example/pdnight/domain/user/presentation/controller/HobbyController.java
@@ -1,6 +1,8 @@
 package org.example.pdnight.domain.user.presentation.controller;
 
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.pdnight.domain.user.application.hobbyUseCase.HobbyService;
 import org.example.pdnight.domain.user.presentation.dto.hobbyDto.request.HobbyRequest;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "UserTag")
 @RestController
 @RequestMapping("/api/hobbies")
 @RequiredArgsConstructor
@@ -19,6 +22,7 @@ public class HobbyController {
     private final HobbyService hobbyService;
 
     @PostMapping
+    @Operation(summary = "취미 추가", description = "취미을 추가한다")
     public ResponseEntity<ApiResponse<HobbyResponse>> createHobby(
             @Validated @RequestBody HobbyRequest dto
     ){
@@ -28,6 +32,7 @@ public class HobbyController {
     }
 
     @GetMapping
+    @Operation(summary = "취미 조회", description = "취미 목록을 조회한다")
     private ResponseEntity<ApiResponse<List<HobbyResponse>>> searchHobby(
             @RequestParam (required = false)  String searchHobby
     ){

--- a/src/main/java/org/example/pdnight/domain/user/presentation/controller/ReviewController.java
+++ b/src/main/java/org/example/pdnight/domain/user/presentation/controller/ReviewController.java
@@ -1,5 +1,7 @@
 package org.example.pdnight.domain.user.presentation.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.pdnight.domain.user.application.reviewUserCase.ReviewService;
 import org.example.pdnight.domain.user.presentation.dto.reviewDto.request.ReviewRequest;
@@ -15,6 +17,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Review")
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
@@ -23,6 +26,7 @@ public class ReviewController {
 
     // -------------------------- Command Api -------------------------------------------------//
     @PostMapping("/posts/{postId}/participants/{userId}/review")
+    @Operation(summary = "리뷰 등록", description = "상대방의 리뷰를 작성한다")
     public ResponseEntity<ApiResponse<ReviewResponse>> createReview(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long postId,
@@ -38,6 +42,7 @@ public class ReviewController {
 
     //사용자가 받은 리뷰 리스트 조회
     @GetMapping("/users/{userId}/review")
+    @Operation(summary = "사용자 리뷰 조회", description = "사용자의 리뷰를 조회한다")
     public ResponseEntity<ApiResponse<PagedResponse<ReviewResponse>>> getReviews(
             @PathVariable("userId") Long userId,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
@@ -48,6 +53,7 @@ public class ReviewController {
 
     //내가 받은 리뷰 리스트 조회
     @GetMapping("/users/my/review")
+    @Operation(summary = "내 리뷰 조회", description = "본인이 받은 리뷰를 조회한다")
     public ResponseEntity<ApiResponse<PagedResponse<ReviewResponse>>> getMyReviews(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
@@ -59,6 +65,7 @@ public class ReviewController {
 
     //내가 작성한 리뷰 리스트 조회
     @GetMapping("/users/my/writtenReview")
+    @Operation(summary = "작성한 리뷰 조회", description = "본인이 작성한 리뷰를 조회한다")
     public ResponseEntity<ApiResponse<PagedResponse<ReviewResponse>>> getMyWrittenReviews(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)

--- a/src/main/java/org/example/pdnight/domain/user/presentation/controller/TechStackController.java
+++ b/src/main/java/org/example/pdnight/domain/user/presentation/controller/TechStackController.java
@@ -1,5 +1,7 @@
 package org.example.pdnight.domain.user.presentation.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.pdnight.domain.user.application.techStackUseCase.TechStackService;
 import org.example.pdnight.domain.user.presentation.dto.techStackDto.request.TechStackRequest;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "UserTag")
 @RestController
 @RequestMapping("/api/tech-stacks")
 @RequiredArgsConstructor
@@ -18,18 +21,20 @@ public class TechStackController {
     public final TechStackService techStackService;
 
     @PostMapping
+    @Operation(summary = "기술 스택 추가", description = "기술 스택을 추가한다")
     public ResponseEntity<ApiResponse<TechStackResponse>> createTechStack(
             @Validated @RequestBody TechStackRequest dto
-            ){
+    ) {
         TechStackResponse techStack = techStackService.createTechStack(dto);
 
-        return ResponseEntity.ok(ApiResponse.ok("기술 스택이 성공적으로 생성 되었습니다",techStack));
+        return ResponseEntity.ok(ApiResponse.ok("기술 스택이 성공적으로 생성 되었습니다", techStack));
     }
 
     @GetMapping
+    @Operation(summary = "기술 스택 조회", description = "기술 스택 목록을 조회한다")
     public ResponseEntity<ApiResponse<List<TechStackResponse>>> getTechStackList(
-            @RequestParam (required = false) String techStack
-    ){
+            @RequestParam(required = false) String techStack
+    ) {
         List<TechStackResponse> techStackResponseList = techStackService.searchTechStackList(techStack);
         return ResponseEntity.ok(ApiResponse.ok("기술 스택 검색에 성공했습니다!", techStackResponseList));
     }

--- a/src/main/java/org/example/pdnight/domain/user/presentation/controller/UserController.java
+++ b/src/main/java/org/example/pdnight/domain/user/presentation/controller/UserController.java
@@ -1,5 +1,6 @@
 package org.example.pdnight.domain.user.presentation.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.example.pdnight.domain.user.application.userUseCase.UserService;
 import org.example.pdnight.domain.user.presentation.dto.userDto.request.GiveCouponRequest;
@@ -28,6 +29,7 @@ public class UserController {
     // --------------- users
     // 본인 프로필 수정
     @PatchMapping("/users/my/profile")
+    @Operation(summary = "프로필 수정", description = "본인의 프로필을 수정한다", tags = {"User"})
     public ResponseEntity<ApiResponse<UserResponse>> updateMyProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody UserUpdateRequest request
@@ -43,6 +45,7 @@ public class UserController {
     // --------------- users/follow
     //팔로우
     @PostMapping("/users/{userId}/follow")
+    @Operation(summary = "팔로우", description = "상대방을 팔로우한다", tags = {"Follow"})
     public ResponseEntity<ApiResponse<FollowResponse>> follow(
             @PathVariable Long userId,
             @AuthenticationPrincipal CustomUserDetails loginUser
@@ -54,6 +57,7 @@ public class UserController {
 
     //언팔로우
     @DeleteMapping("/users/{userId}/follow")
+    @Operation(summary = "언팔로우", description = "팔로우를 취소한다", tags = {"Follow"})
     public ResponseEntity<ApiResponse<Void>> unfollow(
             @PathVariable Long userId,
             @AuthenticationPrincipal CustomUserDetails loggedInUser
@@ -65,6 +69,7 @@ public class UserController {
     // --------------- coupons
     // 쿠폰사용
     @PatchMapping("/users/user-coupons/{id}")
+    @Operation(summary = "쿠폰 사용", description = "본인의 쿠폰을 사용한다", tags = {"Coupon"})
     public ResponseEntity<ApiResponse<UserCouponResponse>> useCoupon(
             @PathVariable Long id,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -76,12 +81,14 @@ public class UserController {
     // --------------------- Admin Command Api ------------------------------------------------//
     // --------------- users
     @PatchMapping("/admin/users/{id}/nickname")
+    @Operation(summary = "[관리자] 닉네임 강제 변경", description = "관리자가 사용자의 닉네임을 강제로 변경한다", tags = {"AdminUser"})
     public ResponseEntity<ApiResponse<UserResponse>> adminUpdateNickname(@PathVariable Long id,
                                                                          @RequestBody UserNicknameUpdate dto) {
         return ResponseEntity.ok(ApiResponse.ok("닉네임이 변경되었습니다.", userService.updateNickname(id, dto)));
     }
 
     @DeleteMapping("/admin/users/{id}")
+    @Operation(summary = "[관리자] 강제 회원탈퇴", description = "관리자가 사용자를 회원탈퇴 시킨다", tags = {"AdminUser"})
     public ResponseEntity<ApiResponse<Void>> adminDeleteUser(@PathVariable Long id) {
         userService.delete(id);
         return ResponseEntity.ok(ApiResponse.ok("회원탈퇴 시켰습니다.", null));
@@ -90,6 +97,7 @@ public class UserController {
     // --------------- coupons
     // 사용자에게 쿠폰 부여
     @PostMapping("/admin/users/coupons")
+    @Operation(summary = "[관리자] 사용자에게 쿠폰 부여", description = "관리자가 사용자에게 쿠폰을 부여한다", tags = {"AdminCoupon"})
     public ResponseEntity<ApiResponse<UserCouponResponse>> giveCouponToUser(
             @RequestBody GiveCouponRequest request
     ) {
@@ -102,6 +110,7 @@ public class UserController {
     // --------------- users
     // 내 프로필 조회
     @GetMapping("/users/my/profile")
+    @Operation(summary = "내 프로필 조회", description = "본인의 프로필을 조회한다", tags = {"User"})
     public ResponseEntity<ApiResponse<UserResponse>> getMyProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
@@ -114,6 +123,7 @@ public class UserController {
 
     // 유저 프로필 조회
     @GetMapping("/users/{id}/profile")
+    @Operation(summary = "사용자 프로필 조회", description = "다른 사용자의 프로필을 조회한다", tags = {"User"})
     public ResponseEntity<ApiResponse<UserResponse>> getProfile(
             @PathVariable Long id
     ) {
@@ -125,6 +135,7 @@ public class UserController {
 
     //유저 검색
     @GetMapping("/users/search")
+    @Operation(summary = "사용자 검색 조회", description = "사용자를 검색해서 조회한다", tags = {"User"})
     public ResponseEntity<ApiResponse<PagedResponse<UserResponse>>> searchUsers(
             @RequestParam String search,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
@@ -138,6 +149,7 @@ public class UserController {
 
     //평가 조회
     @GetMapping("/users/{id}/evaluation")
+    @Operation(summary = "사용자 평가 조회", description = "사용자의 평가를 조회한다", tags = {"User"})
     public ResponseEntity<ApiResponse<UserEvaluationResponse>> getEvaluation(
             @PathVariable Long id
     ) {
@@ -150,6 +162,7 @@ public class UserController {
     // --------------- users/follow
     //내 팔로잉 목록 조회
     @GetMapping("/users/my/following")
+    @Operation(summary = "내 팔로잉 목록 조회", description = "본인의 팔로잉 목록을 조회한다", tags = {"Follow"})
     public ResponseEntity<ApiResponse<PagedResponse<FollowingResponse>>> getFollowings(
             @AuthenticationPrincipal CustomUserDetails loggedInUser,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
@@ -163,6 +176,7 @@ public class UserController {
 
     // 내 쿠폰목록 조회
     @GetMapping("/users/my/user-coupons")
+    @Operation(summary = "내 쿠폰 목록 조회", description = "본인의 쿠폰 목록을 조회한다", tags = {"Coupon"})
     public ResponseEntity<ApiResponse<PagedResponse<UserCouponResponse>>> getMyCoupons(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PageableDefault() Pageable pageable
@@ -173,6 +187,7 @@ public class UserController {
     // --------------------- Admin 조회 Api ----------------------------------------------------//
     // --------------- users
     @GetMapping("/admin/users")
+    @Operation(summary = "[관리자] 전체 사용자 조회", description = "서비스에 가입한 사용자 목록을 조회한다", tags = {"AdminUser"})
     public ResponseEntity<ApiResponse<PagedResponse<UserResponse>>> adminGetAllUsers(
             @PageableDefault() Pageable pageable
     ) {

--- a/src/main/java/org/example/pdnight/domain/user/presentation/dto/couponDto/request/CouponRequest.java
+++ b/src/main/java/org/example/pdnight/domain/user/presentation/dto/couponDto/request/CouponRequest.java
@@ -1,13 +1,15 @@
 package org.example.pdnight.domain.user.presentation.dto.couponDto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class CouponRequest {
-    @NotNull
-    private Long couponId;
+    @Schema(description = "쿠폰 정보", example = "couponInfo")
     @NotNull
     private String couponInfo;
+
+    @Schema(description = "쿠폰 유효 기간", example = "20")
     private Integer defaultDeadlineDays;
 }

--- a/src/main/java/org/example/pdnight/domain/user/presentation/dto/hobbyDto/request/HobbyRequest.java
+++ b/src/main/java/org/example/pdnight/domain/user/presentation/dto/hobbyDto/request/HobbyRequest.java
@@ -1,11 +1,13 @@
 package org.example.pdnight.domain.user.presentation.dto.hobbyDto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class HobbyRequest {
 
+    @Schema(description = "취미", example = "러닝")
     @NotNull
     String hobby;
 

--- a/src/main/java/org/example/pdnight/domain/user/presentation/dto/reviewDto/request/ReviewRequest.java
+++ b/src/main/java/org/example/pdnight/domain/user/presentation/dto/reviewDto/request/ReviewRequest.java
@@ -1,5 +1,6 @@
 package org.example.pdnight.domain.user.presentation.dto.reviewDto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -8,8 +9,11 @@ import java.math.BigDecimal;
 
 @Getter
 public class ReviewRequest {
+    @Schema(description = "평가 점수", example = "3")
     @NotNull
     private BigDecimal rate;
+
+    @Schema(description = "리뷰 내용", example = "comment")
     @Size(max = 30)
     private String comment;
 }

--- a/src/main/java/org/example/pdnight/domain/user/presentation/dto/techStackDto/request/TechStackRequest.java
+++ b/src/main/java/org/example/pdnight/domain/user/presentation/dto/techStackDto/request/TechStackRequest.java
@@ -1,5 +1,6 @@
 package org.example.pdnight.domain.user.presentation.dto.techStackDto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -7,6 +8,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class TechStackRequest {
+    @Schema(description = "기술 스택", example = "JPA")
     @NotNull
     private String techStack;
 }

--- a/src/main/java/org/example/pdnight/domain/user/presentation/dto/userDto/request/GiveCouponRequest.java
+++ b/src/main/java/org/example/pdnight/domain/user/presentation/dto/userDto/request/GiveCouponRequest.java
@@ -1,10 +1,14 @@
 package org.example.pdnight.domain.user.presentation.dto.userDto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 public class GiveCouponRequest {
+    @Schema(description = "부여할 사용자 ID", example = "2")
     Long userId;
+
+    @Schema(description = "부여할 쿠폰 ID", example = "1")
     Long couponId;
 
     private GiveCouponRequest(Long userId,Long couponId){

--- a/src/main/java/org/example/pdnight/domain/user/presentation/dto/userDto/request/UserUpdateRequest.java
+++ b/src/main/java/org/example/pdnight/domain/user/presentation/dto/userDto/request/UserUpdateRequest.java
@@ -1,18 +1,36 @@
 package org.example.pdnight.domain.user.presentation.dto.userDto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
 public class UserUpdateRequest {
+    @Schema(description = "취미 ID 목록", example = "[1, 2]")
     private List<Long> hobbyIdList;
+
+    @Schema(description = "기술 스택 ID 목록", example = "[2]")
     private List<Long> techStackIdList;
+
+    @Schema(description = "사용자 이름", example = "name")
     private String name;
+
+    @Schema(description = "사용자 닉네임", example = "nickname")
     private String nickname;
+
+    @Schema(description = "사용자 성별", example = "MALE")
     private String gender;
+
+    @Schema(description = "사용자 나이", example = "30")
     private Long age;
+
+    @Schema(description = "사용자 직업 카테고리", example = "BACK_END_DEVELOPER")
     private String jobCategory;
+
+    @Schema(description = "사용자 지역", example = "PANGYO_DONG")
     private String region;
+
+    @Schema(description = "사용자 한마디", example = "안녕하세요! 5년차 백엔드 개발자입니다. Spring Boot와 마이크로서비스 아키텍처에 깊은 관심이 있으며, 클린코드와 TDD를 지향합니다.")
     private String comment;
 }

--- a/src/main/java/org/example/pdnight/global/config/SecurityConfig.java
+++ b/src/main/java/org/example/pdnight/global/config/SecurityConfig.java
@@ -36,6 +36,8 @@ public class SecurityConfig {
                         .requestMatchers("/chat/view").permitAll()
                         .requestMatchers("/chat/view/enter/**").permitAll()
                         .requestMatchers("/health").permitAll()
+                        .requestMatchers("/api-docs", "/api-docs/**").permitAll()
+                        .requestMatchers("/swagger-ui", "/swagger-ui/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .build();

--- a/src/main/java/org/example/pdnight/global/config/SpringDocConfig.java
+++ b/src/main/java/org/example/pdnight/global/config/SpringDocConfig.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.Configuration;
 
                 @Tag(name = "AdminPost", description = "관리자/게시글 기능"),
                 @Tag(name = "Post", description = "게시글 기능"),
+                @Tag(name = "PostTag", description = "게시글 태그 기능"),
                 @Tag(name = "Participate", description = "게시글 참여 기능"),
                 @Tag(name = "PostLike", description = "게시글 좋아요 기능"),
                 @Tag(name = "Invite", description = "게시글 초대 기능"),

--- a/src/main/java/org/example/pdnight/global/config/SpringDocConfig.java
+++ b/src/main/java/org/example/pdnight/global/config/SpringDocConfig.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Configuration;
         info = @Info(
                 title = "🌃 판교의 밤 (PDNight) API Document",
                 description = "PDNight Spring Doc API Document",
-                version = "v4" //개발 버전
+                version = "v5" //개발 버전
         ),
         tags = {
                 @Tag(name = "Auth", description = "인증 기능"),

--- a/src/main/java/org/example/pdnight/global/config/SpringDocConfig.java
+++ b/src/main/java/org/example/pdnight/global/config/SpringDocConfig.java
@@ -1,0 +1,60 @@
+package org.example.pdnight.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.security.SecuritySchemes;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        info = @Info(
+                title = "🌃 판교의 밤 (PDNight) API Document",
+                description = "PDNight Spring Doc API Document",
+                version = "v4" //개발 버전
+        ),
+        tags = {
+                @Tag(name = "Auth", description = "인증 기능"),
+
+                @Tag(name = "AdminUser", description = "관리자/사용자 기능"),
+                @Tag(name = "User", description = "사용자 기능"),
+                @Tag(name = "UserTag", description = "취미, 기술스택 기능"),
+                @Tag(name = "Follow", description = "팔로우 기능"),
+
+                @Tag(name = "AdminPost", description = "관리자/게시글 기능"),
+                @Tag(name = "Post", description = "게시글 기능"),
+                @Tag(name = "Participate", description = "게시글 참여 기능"),
+                @Tag(name = "PostLike", description = "게시글 좋아요 기능"),
+                @Tag(name = "Invite", description = "게시글 초대 기능"),
+
+                @Tag(name = "Comment", description = "댓글 기능"),
+                @Tag(name = "Review", description = "리뷰 기능"),
+
+                @Tag(name = "AdminPromotion", description = "관리자/프로모션 기능"),
+                @Tag(name = "Promotion", description = "프로모션 기능"),
+
+                @Tag(name = "AdminCoupon", description = "관리자/쿠폰 기능"),
+                @Tag(name = "Coupon", description = "쿠폰 기능"),
+
+                @Tag(name = "Notification", description = "알림 기능"),
+                @Tag(name = "Chat", description = "채팅방 기능"),
+        },
+        security = {
+                @SecurityRequirement(name = "Bearer Authentication"),
+        }
+)
+@SecuritySchemes({
+        @SecurityScheme(name = "Bearer Authentication",
+                type = SecuritySchemeType.HTTP,
+                in = SecuritySchemeIn.HEADER,
+                paramName = "Authorization",
+                scheme = "bearer",
+                description = "로그인 후 발급되는 JWT 토큰을 입력하세요."
+        ),
+})
+@Configuration
+public class SpringDocConfig {
+}

--- a/src/main/java/org/example/pdnight/global/filter/JwtFilter.java
+++ b/src/main/java/org/example/pdnight/global/filter/JwtFilter.java
@@ -47,6 +47,11 @@ public class JwtFilter implements Filter {
             return;
         }
 
+        if (url.startsWith("/api-docs") || url.startsWith("/swagger-ui")) {
+            chain.doFilter(request, response);
+            return;
+        }
+
         if (url.startsWith("/health")) {
 
             chain.doFilter(request, response);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,6 +23,10 @@ logging.level.org.springframework.data.elasticsearch.client.WIRE= TRACE
 springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/swagger-ui
 springdoc.swagger-ui.displayRequestDuration=true
+springdoc.swagger-ui.operationsSorter=(a,b) => {\
+  var order = {'post': 1, 'get': 2, 'patch': 3, 'delete': 4};\
+  return order[a.get('method')] - order[b.get('method')];\
+  }
 
 #spring.data.redis.repositories.enabled=false
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,11 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 logging.config=classpath:logback.xml
 logging.level.org.springframework.data.elasticsearch.client.WIRE= TRACE
 
+# swagger-ui custom path
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.path=/swagger-ui
+springdoc.swagger-ui.displayRequestDuration=true
+
 #spring.data.redis.repositories.enabled=false
 
 # ==============================


### PR DESCRIPTION
## 주요 안내 사항

**localhost:8080/swagger-ui** 로 접속시 사용 가능합니다


채팅 기능의 경우 일부 `@Controller`+`@ResponseBody` 를 사용하지 않아, Swagger에 나타나지 않습니다
`@ResponseBody`를 추가로 넣었다가 오류날거같아서 안했습니다


### 변경사항
application.properties
- api 주소 이름순이면서, post, get, patch, delete 순으로 정렬

SpringDocConfig
- info: api 명세서 설명 작성
- tags: 분류, 작성한 순서대로 표시됨
- SecuritySchemes: token 사용가능하도록 설정

Request 파일
- 의미 있는 값으로 테스트 가능하도록 예시값 추가

Controller 파일
- 각 메서드의 설명 추가