### PR TITLE
fix: 카프카 외 JVM 용량 설정 적용 + docker-compose 파일 분리

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,48 @@
+version: "3.8"
+
+# 배포 안하는 서비스들
+# logstash, filebeat
+
+services:
+  logstash:
+    build:
+      context: logstash/
+      args:
+        ELK_VERSION: 8.14.0
+    volumes:
+      - type: bind
+        source: ./logstash/config/logstash.conf
+        target: /usr/share/logstash/config/logstash.conf
+        read_only: true
+      - type: bind
+        source: ./logstash/pipeline
+        target: /usr/share/logstash/pipeline
+        read_only: true
+    ports:
+      - "5044:5044"
+      - "15000:5000/tcp"
+      - "15000:5000/udp"
+      - "9600:9600"
+    environment:
+      LS_JAVA_OPTS: "-Xms128M -Xmx256M"
+    networks:
+      - elk
+    depends_on:
+      - elasticsearch
+
+  filebeat:
+    build:
+      context: filebeat/
+      args:
+        ELK_VERSION: 8.14.0
+    volumes:
+      - ./log:/usr/share/log/host_logs:ro
+      - ./filebeat/filebeat.yml:/usr/share/filebeat/filebeat.yml
+    environment:
+      SERVER_JAVA_OPTS: "-Xms48M -Xmx96M"
+    networks:
+      - elk
+    depends_on:
+      - logstash
+    entrypoint: >
+      sh -c "chmod go-w /usr/share/filebeat/filebeat.yml && filebeat"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 version: "3.8"
 
-# .env 파일에 아래 값 준비 권장
-# EC2_PRIVATE_IP=10.0.1.23   # VPC 내에서 접속할 프라이빗 IP 또는 호스트네임
+# 배포 하는 서비스들
 
 services:
   redis:
@@ -183,32 +182,6 @@ services:
     networks:
       - elk
 
-  logstash:
-    build:
-      context: logstash/
-      args:
-        ELK_VERSION: 8.14.0
-    volumes:
-      - type: bind
-        source: ./logstash/config/logstash.conf
-        target: /usr/share/logstash/config/logstash.conf
-        read_only: true
-      - type: bind
-        source: ./logstash/pipeline
-        target: /usr/share/logstash/pipeline
-        read_only: true
-    ports:
-      - "5044:5044"
-      - "15000:5000/tcp"
-      - "15000:5000/udp"
-      - "9600:9600"
-    environment:
-      LS_JAVA_OPTS: "-Xms128M -Xmx256M"
-    networks:
-      - elk
-    depends_on:
-      - elasticsearch
-
   kibana:
     build:
       context: kibana/
@@ -227,23 +200,6 @@ services:
       - elk
     depends_on:
       - elasticsearch
-
-  filebeat:
-    build:
-      context: filebeat/
-      args:
-        ELK_VERSION: 8.14.0
-    volumes:
-      - ./log:/usr/share/log/host_logs:ro
-      - ./filebeat/filebeat.yml:/usr/share/filebeat/filebeat.yml
-    environment:
-      SERVER_JAVA_OPTS: "-Xms48M -Xmx96M"
-    networks:
-      - elk
-    depends_on:
-      - logstash
-    entrypoint: >
-      sh -c "chmod go-w /usr/share/filebeat/filebeat.yml && filebeat"  
 
   kafka-exporter:
     image: danielqsj/kafka-exporter:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ services:
 
       # --- JVM/JMX Exporter(javaagent) ---
       - KAFKA_OPTS=-javaagent:/opt/jmx/jmx_prometheus_javaagent.jar=7071:/opt/jmx/kafka-jmx.yml
+      - KAFKA_HEAP_OPTS=-Xms384M -Xmx512M
+      - KAFKA_JVM_PERFORMANCE_OPTS=-XX:+UseG1GC -XX:MaxGCPauseMillis=30 -XX:InitiatingHeapOccupancyPercent=20 -XX:+ExplicitGCInvokesConcurrent
     volumes:
       - Kafka00:/bitnami/kafka
       - ./jmx:/opt/jmx:ro
@@ -87,6 +89,8 @@ services:
       - KAFKA_CFG_LOG_RETENTION_HOURS=168
 
       - KAFKA_OPTS=-javaagent:/opt/jmx/jmx_prometheus_javaagent.jar=7071:/opt/jmx/kafka-jmx.yml
+      - KAFKA_HEAP_OPTS=-Xms384M -Xmx512M
+      - KAFKA_JVM_PERFORMANCE_OPTS=-XX:+UseG1GC -XX:MaxGCPauseMillis=30 -XX:InitiatingHeapOccupancyPercent=20 -XX:+ExplicitGCInvokesConcurrent
     volumes:
       - Kafka01:/bitnami/kafka
       - ./jmx:/opt/jmx:ro
@@ -125,6 +129,8 @@ services:
       - KAFKA_CFG_LOG_RETENTION_HOURS=168
 
       - KAFKA_OPTS=-javaagent:/opt/jmx/jmx_prometheus_javaagent.jar=7071:/opt/jmx/kafka-jmx.yml
+      - KAFKA_HEAP_OPTS=-Xms384M -Xmx512M
+      - KAFKA_JVM_PERFORMANCE_OPTS=-XX:+UseG1GC -XX:MaxGCPauseMillis=30 -XX:InitiatingHeapOccupancyPercent=20 -XX:+ExplicitGCInvokesConcurrent
     volumes:
       - Kafka02:/bitnami/kafka
       - ./jmx:/opt/jmx:ro
@@ -150,6 +156,7 @@ services:
       - Kafka02Service
     networks:
       - kafka_network
+
   elasticsearch:
     build:
       context: elasticsearch/
@@ -167,7 +174,7 @@ services:
       - "9200:9200"
       - "9300:9300"
     environment:
-      ES_JAVA_OPTS: "-Xmx256m -Xms256m"
+      ES_JAVA_OPTS: "-Xms128M -Xmx256M"
       ELASTIC_PASSWORD: elastic
       # Use single node discovery in order to disable production mode and avoid bootstrap checks
       # see https://www.elastic.co/guide/en/elasticsearch/reference/current/bootstrap-checks.html
@@ -196,7 +203,7 @@ services:
       - "15000:5000/udp"
       - "9600:9600"
     environment:
-      LS_JAVA_OPTS: "-Xmx256m -Xms256m"
+      LS_JAVA_OPTS: "-Xms128M -Xmx256M"
     networks:
       - elk
     depends_on:
@@ -214,6 +221,8 @@ services:
         read_only: true
     ports:
       - "5601:5601"
+    environment:
+      SERVER_JAVA_OPTS: "-Xms96M -Xmx128M"
     networks:
       - elk
     depends_on:
@@ -227,6 +236,8 @@ services:
     volumes:
       - ./log:/usr/share/log/host_logs:ro
       - ./filebeat/filebeat.yml:/usr/share/filebeat/filebeat.yml
+    environment:
+      SERVER_JAVA_OPTS: "-Xms48M -Xmx96M"
     networks:
       - elk
     depends_on:

--- a/k6/post-seeding.js
+++ b/k6/post-seeding.js
@@ -54,6 +54,7 @@ export default function () {
         genderLimit: ['MALE','FEMALE','ALL'][Math.floor(Math.random()*3)],
         jobCategoryLimit: ['BACK_END_DEVELOPER','FRONT_END_DEVELOPER','FULL_STACK_DEVELOPER','ETC','ALL'][Math.floor(Math.random()*5)],
         ageLimit: ['AGE_20S','AGE_30S','AGE_40S','AGE_50S','ALL'][Math.floor(Math.random()*5)],
+        tagIdList: [Math.floor(Math.random()*5) + 1, Math.floor(Math.random()*5) + 1],
         isFirstCome: Math.random() < 0.5,
     };
 


### PR DESCRIPTION
## JVM 용량 설정 적용
docker-compose.yml 파일에서 환경 설정으로 JVM 용량 설정 적용

서비스 | 초기 Heap 크기(-Xms) | 최대 Heap 크기(-Xmx)
-- | -- | --
Kafka Container (3개) | 384 | 512
Elasticsearch | 128 | 256
Logstash | 128 | 256
Kibana | 96 | 128
Filebeat | 48 | 96

도커 컨테이너 메모리 사용량 : 약 6GB→ 4GB로 감소
- Logstash, Filebeat 포함 : 4.5 GB
- Logstash, Filebeat 미포함 : 3.8 GB
  - 로그 관련 기능 (Logstash, Filebeat) 빼고 배포하는 것이 안전해보입니다.

## 부하 테스트 진행 완료
K6 테스트 진행
1. user-seeding : 유저 초기 생성
2. post-seeding : 게시글 초기 생성
3. k6-signup-login-participate : 부하 테스트

테스트 이후로도 서버가 살아있는 것 확인했습니다.

## docker-compose.yml
용량 문제로 로그 기능을 배포 안함에 따라 파일 분리
- 배포때 사용하는 파일(docker-compose.yml) 을 기본으로 사용
  - 평상시에도 로그 기능 잘 안쓸것으로 예상됨
- 로그 기능 필요시, docker-compose.local.yml 파일 사용

> 명령어
> 기본 : `docker compose up -d`
> 로그 기능 사용시 : `docker compose -f docker-compose.yml -f docker-compose.local.yml up -d`

---

기타 변경 사항 
> post-seeding : post 작성시 tagIdList 추가된거 수정